### PR TITLE
fix(build): correct entry asset and theme token paths

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,12 +4,12 @@
     <meta charset="UTF-8" />
     <style>
       html {
-        background: url('src/assert/global-loading.gif') no-repeat center;
+        background: url('/src/assets/global-loading.gif') no-repeat center;
       }
     </style>
     <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link href="/src/components/theme/styles/token.css" rel="stylesheet" />
+    <link href="/src/app/presentation/theme/styles/token.css" rel="stylesheet" />
     <title>中网联合系统</title>
   </head>
   <body class="h-full m-0">


### PR DESCRIPTION
## Summary
- fix incorrect asset path references in `index.html`
- align entry HTML with the current theme token / build output layout
- avoid broken resource resolution at runtime

## Scope
- `index.html` only

## Test Plan
- `pnpm build`
