### PR TITLE
docs(scripts): annotate automation scripts

### DIFF
--- a/docs/scripts-annotations.md
+++ b/docs/scripts-annotations.md
@@ -1,0 +1,207 @@
+# scripts 注解文档
+
+本文档按“执行入口 -> 关键函数 -> 关键判断 -> 输出/退出码 -> 失败排查”整理 `scripts/` 目录中的 3 个脚本，面向需要读懂 CI 脚本行为的开发者。
+
+---
+
+## 1) `scripts/check-px-whitelist.mjs`
+
+### 作用
+
+该脚本用于检查 **增量改动**（不是全量仓库）中的新增行，是否出现不被设计契约允许的硬编码 `px`。如果有违规项，脚本返回非零退出码，阻断 CI。
+
+### 输入
+
+- CLI 参数
+  - `--mode=auto|working-tree|branch`
+  - `--base-ref=<ref>`
+- 环境变量
+  - `GITHUB_BASE_REF`
+  - `PX_BASE_REF`
+- 契约文件
+  - `docs/design-contract.yaml`
+
+### 执行顺序（入口到结束）
+
+1. `main()` 启动。
+2. `parseArgs()` 解析模式和可选基线分支。
+3. `getDiffText(mode, baseRef)` 采集 diff：
+   - `working-tree`：采集暂存 + 未暂存差异。
+   - `branch`：对比 `mergeBase...HEAD`。
+   - `auto`：有本地改动则走 working-tree，否则走 branch。
+4. `parsePxWhitelist()` 从设计契约提取允许的 `px` 白名单（边框、断点、阴影、圆角）。
+5. `parseAddedLines(diffText)` 从 unified diff 里提取新增行，并记录文件与行号。
+6. 遍历新增行：
+   - 用正则匹配所有 `px`。
+   - `isAllowedPx()` 进行“白名单 + 语义关键词”双重判定。
+7. 若存在违规项：打印 `文件:行号 [px值] 内容` 并 `process.exit(1)`；否则打印通过信息。
+
+### 关键函数注解
+
+- `runGit(args, { allowFail })`
+  - 统一发起 git 命令。
+  - 默认严格失败（抛错）。
+  - `allowFail=true` 时不抛错，返回空输出，供上层走 fallback。
+
+- `resolveBaseRef(baseRefArg)`
+  - 逐级解析分支基线：
+    1. CLI/`PX_BASE_REF`
+    2. `GITHUB_BASE_REF`
+    3. upstream
+    4. `origin/HEAD`
+    5. `origin/dev`, `dev`, `origin/master`, `origin/main`, `master`, `main`
+  - 全部失败时抛错并输出尝试过的 ref 列表。
+
+- `getMergeBase(baseRef)`
+  - 计算 `HEAD` 与基线的 merge-base。
+  - 常见失败原因：浅克隆导致历史不足（CI `fetch-depth` 太小）。
+
+- `parseAddedLines(diffText)`
+  - 解析 unified diff：
+    - `+++ b/...` 切换当前文件。
+    - `@@` 读取新增段起始行号。
+    - `+` 行计入检查集。
+    - `-` 行不推进新增侧行号。
+    - 空格上下文行推进新增侧行号。
+
+- `isAllowedPx(pxToken, line, whitelist)`
+  - 先看数值是否在白名单集合。
+  - 再看该行是否满足语义关键词（例如 border/media/shadow/radius）。
+  - 这是为了避免“数值正确但语义错误”被误放行。
+
+### 成功/失败条件
+
+- 成功：无违规项，退出码 `0`。
+- 失败：存在违规项或无法解析有效基线，退出码 `1`。
+
+### CI 常见调用
+
+```bash
+node scripts/check-px-whitelist.mjs --mode=branch
+```
+
+### 失败排查
+
+- 报 `Unable to resolve a base reference`：检查 PR 环境中的 `GITHUB_BASE_REF` 与远端引用可用性。
+- 报 `Unable to compute merge-base`：检查 checkout 深度，建议 `fetch-depth: 0`。
+- 误报某个 px：检查设计契约白名单和该行语义关键词是否匹配。
+
+---
+
+## 2) `scripts/check-unwrap-allowlist.mjs`
+
+### 作用
+
+该脚本用于限制 `unWrap` 的使用范围：只有白名单文件允许出现 `unWrap`。若白名单外命中，则 CI 失败。
+
+### 输入
+
+- 内置白名单：`ALLOWED_FILES`
+- 搜索范围：`SEARCH_GLOBS`（`ts/tsx/vue/js/mjs/cjs`）
+
+### 执行顺序（入口到结束）
+
+1. `run()` 启动。
+2. `searchUnWrapUsage()` 搜索命中：
+   - 优先 `rg`。
+   - 若系统没有 `rg`（ENOENT），回退 `git grep`。
+3. 若状态码是 `1` 或空输出，视为“未命中”，直接通过。
+4. `parseRipgrepLine()` 解析 `file:line:content`。
+5. 过滤白名单外命中项。
+6. 有违规则打印详情并 `process.exit(1)`，否则通过。
+
+### 关键函数注解
+
+- `searchUnWrapUsage()`
+  - `rg` 更快，适合 CI。
+  - 仅在 `rg` 缺失时回退，不吞掉其它类型错误。
+  - 仅扫描源码文件，避免将 workflow/文档中的文本误报为违规。
+
+- `parseRipgrepLine(line)`
+  - 通过前两个冒号拆分，保留后续内容原样，避免内容中冒号造成误拆。
+
+### 成功/失败条件
+
+- 成功：
+  - 没有 `unWrap` 命中；或
+  - 命中全部位于白名单文件。
+- 失败：白名单外命中任意一条。
+
+### CI 常见调用
+
+```bash
+node scripts/check-unwrap-allowlist.mjs
+```
+
+### 失败排查
+
+- 报白名单外命中：根据输出文件路径决定是否改代码或扩白名单。
+- 报搜索工具错误：检查 runner 是否安装 `rg`，或让脚本回退 `git grep`。
+
+---
+
+## 3) `scripts/upload-sourcemaps.mjs`
+
+### 作用
+
+该脚本在构建后上传 `dist/assets` 下的 `.map` 文件到 sourcemap 服务，支持线上错误堆栈还原。
+
+### 输入
+
+- 环境变量
+  - `DIST_DIR`（默认 `../dist/assets`）
+  - `SOURCEMAP_RESOLVER_ENDPOINT`（默认 `http://localhost:3001`）
+
+### 执行顺序（入口到结束）
+
+1. `main()` 启动并打印配置。
+2. 检查 `DIST_DIR` 是否存在，不存在直接失败退出。
+3. 扫描目录中的 `.map` 文件。
+4. 若没有 `.map`，打印提示并正常结束。
+5. 遍历文件并调用 `uploadSourceMap(filePath)`：
+   - 构造 `PUT /v1/sourcemaps?filename=...`
+   - 非 2xx 视为单文件上传失败。
+6. 汇总成功/失败数量。
+7. 若存在失败数，`process.exit(1)`；否则成功退出。
+
+### 关键函数注解
+
+- `uploadSourceMap(filePath)`
+  - 读取单个 `.map` 文件内容。
+  - 向 resolver 发起 `PUT`。
+  - 非 2xx 抛错，由上层统计失败。
+
+- `main()`
+  - 采取“逐个上传 + 汇总判定”的策略：
+    - 单文件失败不立刻中断。
+    - 最后统一根据 `failed` 决定退出码，便于 CI 明确感知整体成功/失败。
+
+### 成功/失败条件
+
+- 成功：
+  - 所有 `.map` 上传成功；或
+  - 目录内无 `.map` 文件。
+- 失败：目录不存在、任一上传失败、或未捕获异常。
+
+### CI 常见调用
+
+```bash
+pnpm build
+node scripts/upload-sourcemaps.mjs
+```
+
+### 失败排查
+
+- 目录不存在：确认已执行构建，且 `DIST_DIR` 指向正确。
+- 无 `.map`：确认构建配置开启 sourcemap。
+- 非 2xx：检查 endpoint 地址、权限、服务端路由、body 限制。
+
+---
+
+## 补充：为什么这三类脚本要做成“可失败即中断 CI”的守卫
+
+- `check-px-whitelist`：防止设计约束失效。
+- `check-unwrap-allowlist`：防止高风险 API 扩散。
+- `upload-sourcemaps`：保证线上错误可追溯。
+
+它们共同目标是：把“上线后难以补救的问题”前移到 CI 阶段尽早失败。

--- a/scripts/check-px-whitelist.mjs
+++ b/scripts/check-px-whitelist.mjs
@@ -4,12 +4,110 @@ import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { spawnSync } from 'node:child_process'
 
+/**
+ * check-px-whitelist.mjs —— px 硬编码白名单守卫脚本
+ *
+ * 【目的】
+ * 项目使用设计契约（design-contract.yaml）统一管理允许出现的 px 值。
+ * 本脚本在 CI 或本地 pre-commit 钩子中运行，扫描 git diff 中"新增的行"，
+ * 检查其中是否包含不在白名单内的 px 值。
+ * 如果发现违规的 px 用法，脚本以 exit(1) 退出，阻断提交或流水线。
+ *
+ * 【运行模式（mode）】
+ * 脚本通过 parseArgs() 解析命令行参数，支持三种模式：
+ *
+ *   1. auto（默认）
+ *      - 自动判断当前环境：如果工作区有未提交的改动，走 working-tree 逻辑；
+ *        否则走 branch 逻辑。适合 pre-commit 钩子等场景。
+ *
+ *   2. working-tree
+ *      - 只检查工作区中尚未提交的改动（即 `git diff` 的输出）。
+ *      - 通过 hasWorkingTreeChanges() 判断是否存在改动。
+ *
+ *   3. branch
+ *      - 检查当前分支相对于基准分支（base ref）的所有新增内容。
+ *      - 流程：resolveBaseRef() 确定基准分支 → getMergeBase() 计算
+ *        merge-base → 执行 `git diff mergeBase...HEAD`，拿到完整差异。
+ *      - 适合 CI 流水线中对整个 PR/MR 的增量检查。
+ *
+ * 【关键函数说明】
+ *
+ *   parseArgs()
+ *     解析 CLI 参数，提取 mode 和可选的 baseRef。
+ *
+ *   runGit(args, { allowFail })
+ *     封装 spawnSync 执行 git 命令。
+ *     - allowFail = false（默认）：命令失败时直接抛错终止脚本。
+ *     - allowFail = true：用于"探测型"调用（例如检查某个 ref 是否存在），
+ *       失败时不抛错，而是返回空字符串，由上层逻辑做 fallback 处理。
+ *
+ *   refExists(ref)
+ *     检查给定的 git ref（分支名/标签/commit）是否存在。
+ *
+ *   pickExistingRef(...refs)
+ *     从候选 ref 列表中选第一个存在的。用于兼容不同仓库的默认分支名
+ *     （例如 main vs master）。
+ *
+ *   getTrackingRef()
+ *     获取当前分支的远程追踪分支（upstream）。如果没有设置 upstream，
+ *     返回 undefined，上层会 fallback 到默认分支。
+ *
+ *   resolveBaseRef(baseRefArg)
+ *     确定用于 diff 比较的基准 ref。优先使用用户显式传入的 baseRefArg；
+ *     否则依次尝试追踪分支、origin/main、origin/master 等常见默认值。
+ *
+ *   getMergeBase(baseRef)
+ *     计算当前 HEAD 与基准 ref 的最近公共祖先（merge-base），
+ *     确保只检查当前分支"自己新增"的改动，不误报基准分支已有的内容。
+ *
+ *   getDiffText(mode, baseRefArg)
+ *     根据 mode 执行对应的 git diff 命令，返回统一格式的 diff 文本。
+ *
+ *   parsePxWhitelist()
+ *     读取 docs/design-contract.yaml，解析出两类白名单：
+ *     - px whitelist：全局允许的 px 数值列表。
+ *     - radius allowed_px：圆角等场景额外允许的 px 数值。
+ *     这样开发者只要在设计契约里声明过的 px 值就不会被拦截。
+ *
+ *   parseAddedLines(diffText)
+ *     解析 diff 文本，只提取以 "+" 开头的新增行（同时记录文件路径和行号），
+ *     忽略删除行和上下文行——我们只关心"新写进去的代码"。
+ *
+ *   isAllowedPx(pxToken, line, whitelist)
+ *     判断某个 px 值是否在白名单中。pxToken 是匹配到的数值字符串，
+ *     line 是完整行内容（可能用于上下文判断，如区分 border-radius 等属性）。
+ *
+ *   main()
+ *     入口函数，串联以上所有步骤：
+ *     1. 解析参数，确定模式。
+ *     2. 获取 diff 文本。
+ *     3. 加载白名单。
+ *     4. 解析新增行，逐行用 PX_PATTERN 正则匹配 px 值。
+ *     5. 对每个匹配到的 px 值调用 isAllowedPx() 判断。
+ *     6. 收集所有违规项并输出报告。
+ *     7. 如有违规 → process.exit(1)，CI 流水线失败；全部通过 → exit(0)。
+ *
+ * 【扫描范围】
+ * FILE_PATTERNS 限定只检查 *.ts / *.tsx / *.vue / *.css / *.scss 文件，
+ * 避免对图片、配置文件等产生误报。
+ *
+ * 【CI 行为】
+ * - 通过（exit 0）：diff 中新增行没有 px，或所有 px 值均在白名单内。
+ * - 失败（exit 1）：存在不在白名单内的 px 硬编码，脚本会打印违规详情
+ *   （文件、行号、具体 px 值），方便开发者快速定位并修复。
+ */
+
 const FILE_PATTERNS = ['*.ts', '*.tsx', '*.vue', '*.css', '*.scss']
 const PX_PATTERN = /(\d+(?:\.\d+)?)px\b/g
 
 const CONTRACT_PATH = resolve(process.cwd(), 'docs/design-contract.yaml')
 
+// 解析命令行参数，决定 diff 收集模式与基线。
 const parseArgs = () => {
+  // 读取命令行参数。该脚本只接受 --mode 和 --base-ref 两个可选参数。
+  // 示例：
+  // - node ... --mode=working-tree
+  // - node ... --mode=branch --base-ref=origin/dev
   const args = process.argv.slice(2)
   const modeArg = args.find((arg) => arg.startsWith('--mode='))
   const baseArg = args.find((arg) => arg.startsWith('--base-ref='))
@@ -17,6 +115,10 @@ const parseArgs = () => {
   const mode = modeArg ? modeArg.split('=')[1] : 'auto'
   const baseRef = baseArg ? baseArg.split('=')[1] : undefined
 
+  // mode 只允许 3 种：
+  // - auto: 自动判断（有本地变更走 working-tree，否则走 branch）
+  // - working-tree: 仅比较本地暂存/未暂存变更
+  // - branch: 比较当前分支与基线分支
   if (!['auto', 'working-tree', 'branch'].includes(mode)) {
     throw new Error(`Unsupported --mode value: ${mode}`)
   }
@@ -24,27 +126,43 @@ const parseArgs = () => {
   return { mode, baseRef }
 }
 
+// 统一封装 git 命令；allowFail=true 时返回空输出而不抛错。
 const runGit = (args, { allowFail = false } = {}) => {
+  // 所有 git 调用都通过这里发起，保证：
+  // 1) cwd 一致（仓库根目录）
+  // 2) 输出编码一致（utf8）
+  // 3) 错误策略一致（严格失败 vs 容错探测）
   const result = spawnSync('git', args, {
     cwd: process.cwd(),
     encoding: 'utf8',
   })
 
+  // 默认策略：失败即抛错。
+  // allowFail=true 用于“探测性命令”（例如 upstream 可能不存在）。
+  // 这类命令失败并不一定代表脚本无法继续，可以交给上层走 fallback。
   if (result.status !== 0 && !allowFail) {
     const stderr = result.stderr?.trim() || 'Unknown git error'
     throw new Error(stderr)
   }
 
+  // 统一返回 stdout。若命令失败且 allowFail=true，stdout 通常为空字符串。
+  // 上层通过空字符串/undefined 来判断“该候选不可用”。
   return (result.stdout || '').trimEnd()
 }
 
+// 判断当前仓库中某个 git 引用是否存在。
 const refExists = (ref) =>
+  // 这里不走 runGit，是因为我们只关心状态码，不关心 stdout/stderr 文本。
+  // rev-parse --verify <ref> 成功表示 ref 在当前仓库可解析。
   spawnSync('git', ['rev-parse', '--verify', ref], {
     cwd: process.cwd(),
     encoding: 'utf8',
   }).status === 0
 
+// 按传入顺序返回第一个存在的引用，保留优先级。
 const pickExistingRef = (...refs) => {
+  // 候选按顺序传入，函数按顺序命中；
+  // 因此可通过“传参顺序”表达优先级策略。
   for (const ref of refs) {
     if (!ref) continue
     if (refExists(ref)) {
@@ -55,23 +173,36 @@ const pickExistingRef = (...refs) => {
   return undefined
 }
 
+// 检测是否存在已暂存或未暂存的本地改动。
 const hasWorkingTreeChanges = () => {
+  // 这里用 name-only 仅判断“是否有变更”，不用取完整 diff 文本，开销更低。
+  // staged: 已 git add 的改动
+  // unstaged: 工作区未 add 的改动
   const staged = runGit(['diff', '--cached', '--name-only'], { allowFail: true })
   const unstaged = runGit(['diff', '--name-only'], { allowFail: true })
   return Boolean(staged.trim() || unstaged.trim())
 }
 
+// 解析当前分支 upstream，作为可能的 diff 基线。
 const getTrackingRef = () => {
+  // @{upstream} 在以下情况常见不存在：
+  // - 新建本地分支未设置 upstream
+  // - CI 的 detached HEAD 场景
+  // 因此这里使用 allowFail=true，把失败当“无 upstream”。
   const upstream = runGit(['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{upstream}'], {
     allowFail: true,
   })
   return upstream.trim() || undefined
 }
 
+// 按 参数/环境变量/upstream/fallback 的顺序解析可用基线引用。
 const resolveBaseRef = (baseRefArg) => {
+  // 在 PR/CI/本地开发多场景下，基线引用可能来源不同，
+  // 因此采用“多来源优先级 + 存在性验证”的方式解析基线。
   const githubBaseRef = process.env.GITHUB_BASE_REF?.trim()
   const envBaseRef = process.env.PX_BASE_REF?.trim()
 
+  // 第一优先级：显式输入（CLI/ENV）。
   const explicitCandidates = [baseRefArg]
   if (envBaseRef) {
     explicitCandidates.push(envBaseRef, `origin/${envBaseRef}`)
@@ -80,6 +211,8 @@ const resolveBaseRef = (baseRefArg) => {
   const explicitRef = pickExistingRef(...explicitCandidates)
   if (explicitRef) return explicitRef
 
+  // 第二优先级：GitHub PR 环境给出的 base 分支。
+  // 兼容直接给分支名（dev）与带远端前缀（origin/dev）的情况。
   const githubCandidates = []
   if (githubBaseRef) {
     githubCandidates.push(githubBaseRef, `origin/${githubBaseRef}`)
@@ -88,20 +221,25 @@ const resolveBaseRef = (baseRefArg) => {
   const githubRef = pickExistingRef(...githubCandidates)
   if (githubRef) return githubRef
 
+  // 第三优先级：当前分支 upstream。
   const trackingRef = getTrackingRef()
   const trackedRef = pickExistingRef(trackingRef)
   if (trackedRef) return trackedRef
 
+  // 第四优先级：远端默认分支符号引用（origin/HEAD -> origin/main/dev）。
   const originHead = runGit(['symbolic-ref', '--short', 'refs/remotes/origin/HEAD'], {
     allowFail: true,
   })
   const originHeadRef = pickExistingRef(originHead.trim())
   if (originHeadRef) return originHeadRef
 
+  // 第五优先级：硬编码兜底。
+  // 这里把 dev 放在前面，贴合当前仓库主开发分支。
   const fallbackRefs = ['origin/dev', 'dev', 'origin/master', 'origin/main', 'master', 'main']
   const fallbackRef = pickExistingRef(...fallbackRefs)
   if (fallbackRef) return fallbackRef
 
+  // 所有来源都失败时，输出“尝试过哪些 ref”帮助定位 CI 环境问题。
   const attemptedRefs = [
     baseRefArg,
     envBaseRef,
@@ -120,7 +258,12 @@ const resolveBaseRef = (baseRefArg) => {
   )
 }
 
+// 计算与基线的 merge-base，用于限定分支 diff 窗口。
 const getMergeBase = (baseRef) => {
+  // merge-base 失败的常见原因：
+  // - checkout 深度太浅（没有完整提交历史）
+  // - baseRef 指向的引用并不在当前仓库历史图中
+  // 这里先 allowFail 取结果，再由业务层给出更具可操作性的错误信息。
   const mergeBase = runGit(['merge-base', 'HEAD', baseRef], { allowFail: true }).trim()
   if (!mergeBase) {
     throw new Error(
@@ -130,8 +273,12 @@ const getMergeBase = (baseRef) => {
   return mergeBase
 }
 
+// 根据模式收集 diff 文本：工作区增量或分支与基线差异。
 const getDiffText = (mode, baseRefArg) => {
   if (mode === 'working-tree') {
+    // working-tree 模式只看“当前本地改动”，适合开发者本地自检。
+    // --diff-filter=AM: 仅检查新增/修改文件，忽略删除文件。
+    // --unified=0: 不携带上下文行，减少后续解析复杂度与文本体积。
     const unstaged = runGit([
       'diff',
       '--no-color',
@@ -149,11 +296,15 @@ const getDiffText = (mode, baseRefArg) => {
       '--',
       ...FILE_PATTERNS,
     ])
+    // 将暂存和未暂存 diff 拼接为统一输入，后续统一解析。
     return { diffText: `${unstaged}\n${staged}`, resolvedMode: 'working-tree', baseRef: null }
   }
 
+  // branch / auto 都需要先解析基线并计算 merge-base。
   const baseRef = resolveBaseRef(baseRefArg)
   const mergeBase = getMergeBase(baseRef)
+  // 分支比较窗口：mergeBase...HEAD（三点语法）。
+  // 只拿“当前分支相对基线新增的改动”，避免把基线已有改动混进来。
   const branchDiff = runGit([
     'diff',
     '--no-color',
@@ -168,6 +319,9 @@ const getDiffText = (mode, baseRefArg) => {
     return { diffText: branchDiff, resolvedMode: 'branch', baseRef }
   }
 
+  // auto 模式：
+  // - 无本地改动时，用 branch 结果（更贴近 CI）
+  // - 有本地改动时，切回 working-tree（更贴近开发者当前编辑状态）
   const useWorkingTree = hasWorkingTreeChanges()
   if (!useWorkingTree) {
     return { diffText: branchDiff, resolvedMode: 'branch', baseRef }
@@ -177,9 +331,14 @@ const getDiffText = (mode, baseRefArg) => {
   return { ...workingTree, resolvedMode: 'working-tree', baseRef }
 }
 
+// 从设计token读取并构建允许的 px 白名单集合。
 const parsePxWhitelist = () => {
+  // 这里直接解析 design-contract 原文（而非引入 YAML 解析器），
+  // 目的是降低脚本依赖复杂度，保持 CI 守卫脚本轻量可执行。
   const content = readFileSync(CONTRACT_PATH, 'utf8')
 
+  // 提取 px_whitelist 块和 radius.allowed_px。
+  // 注意：这是面向当前文档结构的“约定式解析”，若token格式大改需同步更新正则。
   const pxWhitelistBlock = content.match(/px_whitelist:\n([\s\S]*?)\n[a-z_]+:/m)?.[1] ?? ''
   const radiusAllowedRaw = content.match(/radius:\n[\s\S]*?allowed_px:\s*\[([^\]]+)\]/m)?.[1] ?? ''
 
@@ -189,6 +348,7 @@ const parsePxWhitelist = () => {
   const radius = new Set()
 
   for (const rawLine of pxWhitelistBlock.split(/\r?\n/)) {
+    // 只处理形如 "- key: value" 的配置行。
     const line = rawLine.trim()
     const entry = line.match(/^-\s*([a-zA-Z0-9_-]+):\s*(.+)$/)
     if (!entry) continue
@@ -210,13 +370,18 @@ const parsePxWhitelist = () => {
     radius.add(`${num}px`)
   })
 
-  // 1px borders are already allowed, but keep it as a hard fallback.
+  // 1px 边框通常在设计系统中是基础允许项，这里做硬兜底避免误拦。
   borderWidth.add('1px')
 
   return { borderWidth, breakpoints, elevation, radius }
 }
 
+// 从 unified diff 中提取新增行，并保留文件与行号信息。
 const parseAddedLines = (diffText) => {
+  // 该函数实现了一个简化版 unified diff 解析器：
+  // - 通过 "+++ b/..." 识别当前文件
+  // - 通过 "@@" 识别新增段起始行号
+  // - 只记录新增行（+），并维护准确行号
   const violationsInput = []
   const lines = diffText.split(/\r?\n/)
   let filePath = ''
@@ -237,16 +402,19 @@ const parseAddedLines = (diffText) => {
     if (!filePath || currentLine === 0) continue
 
     if (line.startsWith('+') && !line.startsWith('+++')) {
+      // 新增行：记录后行号 +1
       violationsInput.push({ filePath, lineNumber: currentLine, content: line.slice(1) })
       currentLine += 1
       continue
     }
 
     if (line.startsWith('-') && !line.startsWith('---')) {
+      // 删除行不推进“新增侧”行号。
       continue
     }
 
     if (line.startsWith(' ')) {
+      // 上下文行会推进新增侧行号。
       currentLine += 1
     }
   }
@@ -254,7 +422,12 @@ const parseAddedLines = (diffText) => {
   return violationsInput
 }
 
+// 结合白名单与语义关键词判断 px 是否允许。
 const isAllowedPx = (pxToken, line, whitelist) => {
+  // 判定策略不是“只看数值是否在白名单”，而是两层判断：
+  // 1) 数值在某个白名单集合内
+  // 2) 行文本出现对应语义关键词（border/media/shadow/radius）
+  // 这样可以减少把“同样数值但错误用途”的场景误放行。
   const text = line.toLowerCase()
 
   if (whitelist.borderWidth.has(pxToken)) {
@@ -277,6 +450,7 @@ const isAllowedPx = (pxToken, line, whitelist) => {
   return false
 }
 
+// 主流程：收集 diff、扫描新增行 px、输出违规并以非零退出。
 const main = () => {
   const { mode, baseRef } = parseArgs()
   const { diffText, resolvedMode, baseRef: resolvedBaseRef } = getDiffText(mode, baseRef)
@@ -292,12 +466,14 @@ const main = () => {
   const dedupe = new Set()
 
   for (const line of addedLines) {
+    // 一行可能出现多个 px（例如 box-shadow），全部提取并逐个判断。
     const pxMatches = [...line.content.matchAll(PX_PATTERN)].map((match) => `${match[1]}px`)
     if (pxMatches.length === 0) continue
 
     for (const pxToken of pxMatches) {
       if (isAllowedPx(pxToken, line.content, whitelist)) continue
 
+      // 用 key 去重，避免同一行同一 px 被重复报告。
       const key = `${line.filePath}:${line.lineNumber}:${pxToken}:${line.content}`
       if (dedupe.has(key)) continue
       dedupe.add(key)

--- a/scripts/check-unwrap-allowlist.mjs
+++ b/scripts/check-unwrap-allowlist.mjs
@@ -2,11 +2,69 @@
 
 import { spawnSync } from 'node:child_process'
 
+/**
+ * check-unwrap-allowlist.mjs —— unWrap 调用守卫脚本
+ *
+ * 【目的】
+ * 项目中 `unWrap`（或类似的解包/断言函数）具有运行时风险——
+ * 如果值为 null/undefined 会直接抛异常。因此我们希望严格控制它的使用范围：
+ * 只有白名单（ALLOWED_FILES）中列出的文件才允许调用 unWrap，
+ * 其他任何文件出现 unWrap 调用都视为违规，CI 将阻断。
+ *
+ * 【白名单机制】
+ * ALLOWED_FILES 是一个 Set，列出了允许使用 unWrap 的文件路径。
+ * 目前只有本脚本自身被允许（因为脚本内部需要引用 unWrap 字符串做搜索）。
+ * 如果某个文件确实需要使用 unWrap，必须先把它加入 ALLOWED_FILES，
+ * 经过代码评审后合入。
+ *
+ * 【搜索策略与双引擎回退】
+ *
+ *   searchUnWrapUsage() 执行实际搜索，采用双引擎策略：
+ *
+ *   第一优先：ripgrep（rg）
+ *     - 速度快，支持 glob 过滤，是首选搜索工具。
+ *     - 使用 SEARCH_GLOBS 指定的文件模式（*.ts, *.tsx, *.vue, *.js, *.mjs, *.cjs）
+ *       进行搜索，避免扫描 node_modules、图片等无关文件。
+ *     - 如果系统上没有安装 rg（spawnSync 返回 ENOENT 错误），
+ *       脚本不会直接失败，而是自动回退到 git grep。
+ *
+ *   回退方案：git grep
+ *     - 任何 git 仓库都自带，不需要额外安装。
+ *     - 使用 GIT_GREP_PATHS（由 SEARCH_GLOBS 转换为 git pathspec 格式，
+ *       例如 ":(glob)**.ts" 这类 glob 语法）来限定搜索范围。
+ *
+ * 【搜索结果状态码含义】
+ *   - status = 0：搜索命中了内容（找到了 unWrap 调用）。
+ *   - status = 1：搜索未命中任何内容——这在本场景下是"通过"的意思，
+ *     说明代码库中没有 unWrap 调用，完全合规。
+ *   - status >= 2 或其他异常：搜索工具自身出错，脚本应报错退出。
+ *
+ * 【parseRipgrepLine(line)】
+ *   解析 rg 或 git grep 的输出行，提取文件路径。
+ *   输出格式通常为 "文件路径:行号:匹配内容"，该函数取出文件路径部分，
+ *   用于后续与白名单比对。
+ *
+ * 【run() 主流程】
+ *   1. 调用 searchUnWrapUsage() 获取所有命中 unWrap 的文件列表。
+ *   2. 如果没有命中 → 直接通过（exit 0）。
+ *   3. 如果有命中 → 逐个检查是否在 ALLOWED_FILES 白名单中：
+ *      - 全部在白名单内 → 通过（exit 0）。
+ *      - 存在不在白名单内的文件 → 打印违规文件列表，exit(1) 阻断 CI。
+ *
+ * 【CI 行为】
+ * - 通过（exit 0）：代码库中无 unWrap 调用，或所有调用均在白名单文件内。
+ * - 失败（exit 1）：发现白名单之外的文件使用了 unWrap，
+ *   脚本输出违规文件路径，开发者需要移除调用或将文件加入白名单后重试。
+ */
+
 const ALLOWED_FILES = new Set(['scripts/check-unwrap-allowlist.mjs'])
 const SEARCH_GLOBS = ['**/*.ts', '**/*.tsx', '**/*.vue', '**/*.js', '**/*.mjs', '**/*.cjs']
+// git grep 使用 pathspec 语法时，需要显式声明 glob 模式。
 const GIT_GREP_PATHS = SEARCH_GLOBS.map((glob) => `:(glob)${glob}`)
 
 const parseRipgrepLine = (line) => {
+  // 解析 "file:line:content" 结构。
+  // 这里手动找前两个冒号，避免 content 内再出现冒号导致误拆分。
   const firstColon = line.indexOf(':')
   const secondColon = line.indexOf(':', firstColon + 1)
 
@@ -26,6 +84,8 @@ const parseRipgrepLine = (line) => {
 }
 
 const searchUnWrapUsage = () => {
+  // 优先使用 rg：更快、输出稳定，适合 CI 大仓库扫描。
+  // 仅扫描源码类型文件，避免把 workflow/文档中的示例文本当成违规。
   const ripgrepArgs = [
     '--line-number',
     '--no-heading',
@@ -46,10 +106,13 @@ const searchUnWrapUsage = () => {
     return ripgrepResult
   }
 
+  // 仅当“系统没有 rg”（ENOENT）时才回退 git grep；
+  // 其他错误（参数错误/权限问题）应直接暴露，不做吞错。
   if (ripgrepResult.error.code !== 'ENOENT') {
     throw ripgrepResult.error
   }
 
+  // 回退到 git grep，保证在最小环境也可运行。
   return spawnSync(
     'git',
     ['grep', '-n', '--fixed-strings', '-e', 'unWrap', '--', ...GIT_GREP_PATHS],
@@ -61,12 +124,14 @@ const searchUnWrapUsage = () => {
 }
 
 const run = () => {
+  // 主流程：先搜，再解析，再做白名单过滤，最后决定退出码。
   const result = searchUnWrapUsage()
 
   if (result.error) {
     throw result.error
   }
 
+  // 约定：搜索类命令 status=1 表示“没找到匹配”，这是成功场景。
   if (result.status !== 0 && result.status !== 1) {
     const stderr = result.stderr?.trim() || 'Unknown ripgrep error'
     throw new Error(stderr)
@@ -83,6 +148,7 @@ const run = () => {
     .map(parseRipgrepLine)
     .filter((value) => value !== null)
 
+  // 白名单外命中即视为违规，阻断 CI。
   const violations = matches.filter((entry) => !ALLOWED_FILES.has(entry.filePath))
 
   if (violations.length > 0) {

--- a/scripts/upload-sourcemaps.mjs
+++ b/scripts/upload-sourcemaps.mjs
@@ -1,9 +1,60 @@
 #!/usr/bin/env node
 /**
- * Source Map 上传脚本
- * 构建后自动上传 .map 文件到 Source Map Resolver 服务
+ * upload-sourcemaps.mjs —— 构建产物 Source Map 上传脚本
  *
- * 用法: node scripts/upload-sourcemaps.mjs
+ * 【目的】
+ * 前端项目打包后会在 dist/assets 目录下生成 .map（Source Map）文件。
+ * 本脚本将这些 .map 文件逐个上传到 Source Map 解析服务（Resolver），
+ * 以便在生产环境出现错误时，能够通过 Source Map 还原出原始源码位置，
+ * 方便排查问题。
+ *
+ * 【环境变量】
+ *
+ *   DIST_DIR
+ *     构建产物目录路径，默认为项目根目录下的 dist/assets。
+ *     如果你的构建输出到了其他位置（例如自定义 Vite outDir），
+ *     可以通过设置此环境变量来覆盖。
+ *
+ *   SOURCEMAP_RESOLVER_ENDPOINT
+ *     Source Map 解析服务的地址，默认为 http://localhost:3001。
+ *     在 CI/CD 环境中通常会设置为内网服务地址或云端服务地址。
+ *
+ * 【__dirname 兼容处理】
+ * 因为本脚本是 ESM 格式（.mjs），不像 CommonJS 那样自带 __dirname，
+ * 所以通过 fileURLToPath(import.meta.url) + path.dirname() 手动构造，
+ * 确保相对路径解析正确。
+ *
+ * 【uploadSourceMap(filePath) —— 单文件上传】
+ *   - 读取指定 .map 文件的内容。
+ *   - 以 PUT 方法发送到 Resolver 服务的 /v1/sourcemaps 端点，
+ *     通过查询参数 filename 传递文件名。
+ *   - 如果上传失败（HTTP 非 2xx 或网络错误），函数会抛出错误，
+ *     但不会终止整个脚本——由 main() 负责捕获并记录。
+ *
+ * 【main() —— 主流程】
+ *   1. 检查 DIST_DIR 是否存在：
+ *      - 不存在 → 说明构建未完成或路径配置错误，直接报错并 exit(1)。
+ *
+ *   2. 扫描 DIST_DIR 下所有 .map 文件：
+ *      - 没有找到任何 .map 文件 → 这不算错误（可能项目配置了不生成 sourcemap），
+ *        脚本正常退出（exit 0）。
+ *
+ *   3. 逐个上传 .map 文件：
+ *      - 每个文件独立上传，单个文件上传失败不会中断后续文件的上传。
+ *      - 失败的文件会被记录到一个失败列表中，并在控制台输出错误信息。
+ *
+ *   4. 上传完毕后统计结果：
+ *      - 如果失败数 > 0 → exit(1)，CI 流水线标记为失败。
+ *      - 如果全部成功 → exit(0)，流水线继续。
+ *
+ * 【顶层错误处理】
+ * main().catch() 捕获未预期的致命错误（如代码 bug、权限问题等），
+ * 打印错误信息并以 exit(1) 退出，确保 CI 不会静默通过。
+ *
+ * 【CI 行为】
+ * - 通过（exit 0）：所有 .map 文件上传成功，或目录下无 .map 文件。
+ * - 失败（exit 1）：DIST_DIR 不存在、或有至少一个 .map 文件上传失败、
+ *   或发生未预期的运行时错误。
  */
 
 import fs from 'node:fs'
@@ -11,18 +62,27 @@ import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
+// DIST_DIR 可被 CI 覆盖；默认使用前端构建产物目录。
 const DIST_DIR = process.env.DIST_DIR || path.join(__dirname, '../dist/assets')
+// 解析服务地址可被环境变量注入；本地默认值用于开发联调。
 const RESOLVER_ENDPOINT = process.env.SOURCEMAP_RESOLVER_ENDPOINT || 'http://localhost:3001'
 
 async function uploadSourceMap(filePath) {
+  // 上传单个 sourcemap：文件名作为 query 参数，文件内容作为请求体。
   const filename = path.basename(filePath)
+  // sourcemap 文件是文本 JSON，这里直接按 Buffer 读取并传输。
   const content = fs.readFileSync(filePath)
 
-  const response = await fetch(`${RESOLVER_ENDPOINT}/v1/sourcemaps?filename=${encodeURIComponent(filename)}`, {
-    method: 'PUT',
-    headers: { 'Content-Type': 'application/json' },
-    body: content,
-  })
+  // 服务端协议：PUT /v1/sourcemaps?filename=<name>
+  // 返回非 2xx 视为上传失败。
+  const response = await fetch(
+    `${RESOLVER_ENDPOINT}/v1/sourcemaps?filename=${encodeURIComponent(filename)}`,
+    {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: content,
+    },
+  )
 
   if (!response.ok) {
     throw new Error(`Failed to upload ${filename}: ${response.status}`)
@@ -32,18 +92,22 @@ async function uploadSourceMap(filePath) {
 }
 
 async function main() {
+  // 主入口：检查目录 -> 扫描文件 -> 逐个上传 -> 汇总结果。
   console.log(`Uploading source maps from: ${DIST_DIR}`)
   console.log(`Target endpoint: ${RESOLVER_ENDPOINT}`)
   console.log('')
 
   if (!fs.existsSync(DIST_DIR)) {
+    // 目录不存在通常说明 build 尚未执行，或 DIST_DIR 指错。
     console.error(`Error: Directory not found: ${DIST_DIR}`)
     process.exit(1)
   }
 
-  const files = fs.readdirSync(DIST_DIR).filter(f => f.endsWith('.map'))
+  // 仅处理 .map 文件，其它构建产物跳过。
+  const files = fs.readdirSync(DIST_DIR).filter((f) => f.endsWith('.map'))
 
   if (files.length === 0) {
+    // 无 sourcemap 视为可接受场景（例如关闭了 sourcemap 输出）。
     console.log('No source map files found.')
     return
   }
@@ -59,6 +123,7 @@ async function main() {
       await uploadSourceMap(path.join(DIST_DIR, file))
       success++
     } catch (err) {
+      // 单文件失败不立即中断：继续上传剩余文件，最后统一给出汇总结果。
       console.error(`✗ Failed: ${file} - ${err.message}`)
       failed++
     }
@@ -68,11 +133,13 @@ async function main() {
   console.log(`Done: ${success} uploaded, ${failed} failed`)
 
   if (failed > 0) {
+    // 只要有失败就返回非零，让 CI 感知并中断发布。
     process.exit(1)
   }
 }
 
-main().catch(err => {
+main().catch((err) => {
+  // 兜底捕获未处理异常，确保脚本在异常场景下返回非零状态码。
   console.error('Error:', err)
   process.exit(1)
 })


### PR DESCRIPTION
## Summary
- add detailed inline annotations for CI / automation guard scripts
- document the purpose, execution flow, and failure modes of the scripts
- add `docs/scripts-annotations.md` as a higher-level reference

## Scope
- documentation-oriented updates around existing automation scripts

## Notes
- this PR is intended to stack on top of `fix/ci-guard-scripts`

## Test Plan
- `git diff --check fix/ci-guard-scripts...HEAD`
- `node --check scripts/check-px-whitelist.mjs`
- `node --check scripts/check-unwrap-allowlist.mjs`
- `node --check scripts/upload-sourcemaps.mjs`
