### PR TITLE
perf(work-order): lazy-load markdown editor and preview chunks

### DIFF
--- a/src/modules/work-order/presentation/WorkOrderCreateModal.vue
+++ b/src/modules/work-order/presentation/WorkOrderCreateModal.vue
@@ -9,8 +9,8 @@ import { useRouter } from 'vue-router'
 import WorkOrderCategorySelect from './WorkOrderCategorySelect'
 
 const AsyncMdEditor = defineAsyncComponent(async () => {
-  const [{ MdEditor }] = await Promise.all([
-    import('md-editor-v3'),
+  const [{ default: MdEditor }] = await Promise.all([
+    import('md-editor-v3/lib/es/MdEditor.mjs'),
     import('md-editor-v3/lib/style.css'),
   ])
 

--- a/src/modules/work-order/presentation/WorkOrderCreateModal.vue
+++ b/src/modules/work-order/presentation/WorkOrderCreateModal.vue
@@ -1,14 +1,21 @@
 <script setup lang="ts">
-import { ref, computed } from 'vue'
-import { NModal, NCard, NForm, NFormItem, NInput, NButton, NSpace } from 'naive-ui'
+import { ref, computed, defineAsyncComponent } from 'vue'
+import { NModal, NCard, NForm, NFormItem, NInput, NButton, NSpace, NSpin } from 'naive-ui'
 import { message } from '@/_utils/discrete_naive_api'
-import { MdEditor } from 'md-editor-v3'
-import 'md-editor-v3/lib/style.css'
 import { useI18n } from 'vue-i18n'
 import { useCreateWorkOrder } from '../application/hooks/useWorkOrderService'
 import { useWorkOrderUpload } from '../application/hooks/useWorkOrderUpload'
 import { useRouter } from 'vue-router'
 import WorkOrderCategorySelect from './WorkOrderCategorySelect'
+
+const AsyncMdEditor = defineAsyncComponent(async () => {
+  const [{ MdEditor }] = await Promise.all([
+    import('md-editor-v3'),
+    import('md-editor-v3/lib/style.css'),
+  ])
+
+  return MdEditor
+})
 
 defineProps<{
   show: boolean
@@ -88,13 +95,21 @@ const handleSubmit = () => {
           />
         </n-form-item>
         <n-form-item :label="$t('domain.workOrder.field.content')">
-          <MdEditor
-            v-model="content"
-            :language="'zh-CN'"
-            style="width: 100%"
-            :preview="false"
-            @on-upload-img="onUploadImg"
-          />
+          <Suspense>
+            <component
+              :is="AsyncMdEditor"
+              v-model="content"
+              :language="'zh-CN'"
+              style="width: 100%"
+              :preview="false"
+              @on-upload-img="onUploadImg"
+            />
+            <template #fallback>
+              <n-spin :show="true" class="editor-loading-shell">
+                <div class="editor-loading-placeholder" />
+              </n-spin>
+            </template>
+          </Suspense>
         </n-form-item>
       </n-form>
       <template #footer>
@@ -145,6 +160,17 @@ const handleSubmit = () => {
 .work-order-create-form-grid :deep(.n-form-item .n-form-item-blank) {
   grid-column: span 8;
   min-width: 0;
+}
+
+.editor-loading-shell {
+  inline-size: 100%;
+}
+
+.editor-loading-placeholder {
+  inline-size: 100%;
+  block-size: 18rem;
+  border-radius: var(--borderRadius-8);
+  background: var(--colorFillQuaternary);
 }
 
 @container work-order-create-form-grid (max-width: 48rem) {

--- a/src/modules/work-order/presentation/WorkOrderDetailPage.vue
+++ b/src/modules/work-order/presentation/WorkOrderDetailPage.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, defineAsyncComponent, ref } from 'vue'
 import { useRoute } from 'vue-router'
 import {
   NSpace,
@@ -14,8 +14,6 @@ import {
   NSpin,
 } from 'naive-ui'
 import { message } from '@/_utils/discrete_naive_api'
-import { MdEditor, MdPreview } from 'md-editor-v3'
-import 'md-editor-v3/lib/style.css'
 import { useI18n } from 'vue-i18n'
 import { useAccountStore } from '@/modules/user/application/stores/useAccountStore'
 import {
@@ -39,6 +37,24 @@ import type { WorkOrderReplyVO } from '../domain/types'
 import WorkOrderStatusBadge from './WorkOrderStatusBadge'
 import WorkOrderScoreSection from './WorkOrderScoreSection.vue'
 import { formatted } from '@/modules/shared/presentation/time'
+
+const AsyncMdPreview = defineAsyncComponent(async () => {
+  const [{ default: MdPreview }] = await Promise.all([
+    import('md-editor-v3/lib/es/MdPreview.mjs'),
+    import('md-editor-v3/lib/preview.css'),
+  ])
+
+  return MdPreview
+})
+
+const AsyncMdEditor = defineAsyncComponent(async () => {
+  const [{ default: MdEditor }] = await Promise.all([
+    import('md-editor-v3/lib/es/MdEditor.mjs'),
+    import('md-editor-v3/lib/style.css'),
+  ])
+
+  return MdEditor
+})
 
 const route = useRoute()
 const { t: $t } = useI18n()
@@ -348,7 +364,14 @@ const handleRelease = () => {
 
       <!-- Content -->
       <n-card :bordered="false">
-        <MdPreview :model-value="detail.content" />
+        <Suspense>
+          <component :is="AsyncMdPreview" :model-value="detail.content" />
+          <template #fallback>
+            <n-spin :show="true" class="markdown-loading-shell">
+              <div class="markdown-preview-loading-placeholder" />
+            </n-spin>
+          </template>
+        </Suspense>
       </n-card>
 
       <n-divider />
@@ -397,20 +420,35 @@ const handleRelease = () => {
               </n-text>
             </n-space>
           </template>
-          <MdPreview :model-value="reply.content" />
+          <Suspense>
+            <component :is="AsyncMdPreview" :model-value="reply.content" />
+            <template #fallback>
+              <n-spin :show="true" class="markdown-loading-shell">
+                <div class="markdown-preview-loading-placeholder" />
+              </n-spin>
+            </template>
+          </Suspense>
         </n-card>
       </n-space>
 
       <!-- Reply editor -->
       <n-card v-if="canReply" :bordered="false">
         <n-space vertical :size="12">
-          <MdEditor
-            v-model="replyContent"
-            :language="'zh-CN'"
-            class="w-full"
-            :preview="false"
-            @on-upload-img="onUploadImg"
-          />
+          <Suspense>
+            <component
+              :is="AsyncMdEditor"
+              v-model="replyContent"
+              :language="'zh-CN'"
+              class="w-full"
+              :preview="false"
+              @on-upload-img="onUploadImg"
+            />
+            <template #fallback>
+              <n-spin :show="true" class="markdown-loading-shell">
+                <div class="markdown-editor-loading-placeholder" />
+              </n-spin>
+            </template>
+          </Suspense>
         </n-space>
       </n-card>
 
@@ -438,6 +476,24 @@ const handleRelease = () => {
   max-width: var(--layout-content-max-width);
   margin: 0 auto;
   padding-inline: var(--spacing-md);
+}
+
+.markdown-loading-shell {
+  inline-size: 100%;
+}
+
+.markdown-preview-loading-placeholder {
+  inline-size: 100%;
+  block-size: 7rem;
+  border-radius: var(--borderRadius-8);
+  background: var(--colorFillQuaternary);
+}
+
+.markdown-editor-loading-placeholder {
+  inline-size: 100%;
+  block-size: 18rem;
+  border-radius: var(--borderRadius-8);
+  background: var(--colorFillQuaternary);
 }
 
 @media (min-width: 768px) {

--- a/src/types/vendor/md-editor-v3.d.ts
+++ b/src/types/vendor/md-editor-v3.d.ts
@@ -1,0 +1,13 @@
+declare module 'md-editor-v3/lib/es/MdEditor.mjs' {
+  import type { DefineComponent } from 'vue'
+
+  const MdEditor: DefineComponent
+  export default MdEditor
+}
+
+declare module 'md-editor-v3/lib/es/MdPreview.mjs' {
+  import type { DefineComponent } from 'vue'
+
+  const MdPreview: DefineComponent
+  export default MdPreview
+}


### PR DESCRIPTION
## Summary
- lazy-load markdown editor usage in work-order create flow
- lazy-load preview and editor-related chunks in work-order detail flow
- add vendor typing support required by the split markdown editor integration

## Scope
- work-order create modal
- work-order detail page
- `md-editor-v3` type declaration

## Test Plan
- `pnpm type-check`
