### PR TITLE
refactor(auth): defer bootstrap work until post-login

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { zhCN, dateZhCN, enUS, dateEnUS, NConfigProvider, darkTheme } from 'naive-ui'
-import { VueQueryDevtools } from '@tanstack/vue-query-devtools'
+import { defineAsyncComponent } from 'vue'
 import { useTheme } from '@/app/presentation/theme/hooks/useTheme'
 import { computed } from 'vue'
 import ErrorBoundary from '@/app/observability/components/ErrorBoundary'
@@ -10,6 +10,12 @@ const { isDark, activeThemeOverrides } = useTheme()
 const naiveTheme = computed(() => (isDark.value ? darkTheme : null))
 const naiveLocale = computed(() => (language.value === 'en' ? enUS : zhCN))
 const naiveDateLocale = computed(() => (language.value === 'en' ? dateEnUS : dateZhCN))
+const queryDevtoolsComponent = import.meta.env.DEV
+  ? defineAsyncComponent(async () => {
+      const module = await import('@tanstack/vue-query-devtools')
+      return module.VueQueryDevtools
+    })
+  : null
 </script>
 <template>
   <!-- 设置移动端字体以及默认bg样式 text-sm md:text-base text-text-main bg-bg-body -->
@@ -25,6 +31,6 @@ const naiveDateLocale = computed(() => (language.value === 'en' ? dateEnUS : dat
       <RouterView></RouterView>
     </ErrorBoundary>
   </n-config-provider>
-  <VueQueryDevtools />
+  <component :is="queryDevtoolsComponent" v-if="queryDevtoolsComponent" />
 </template>
 <style></style>

--- a/src/app/infrastructure/query/tanstack_query_persist_with_dexie/index.ts
+++ b/src/app/infrastructure/query/tanstack_query_persist_with_dexie/index.ts
@@ -1,5 +1,46 @@
 import db from '@/app/infrastructure/storage/dexie'
-import { experimental_createQueryPersister } from '@tanstack/query-persist-client-core'
+import {
+  experimental_createQueryPersister,
+  type PersistedClient,
+  type Persister,
+} from '@tanstack/query-persist-client-core'
+import { getStoredAccessToken } from '@/modules/access/application/token-manager'
+
+const QUERY_CLIENT_CACHE_KEY_PREFIX = 'query-client-cache'
+
+const resolveQueryClientCacheKey = () => {
+  const token = getStoredAccessToken()
+  return `${QUERY_CLIENT_CACHE_KEY_PREFIX}:${token ?? 'anonymous'}`
+}
+
+export const queryClientPersister: Persister = {
+  async persistClient(client: PersistedClient) {
+    await db.queryCache.put({
+      key: resolveQueryClientCacheKey(),
+      value: JSON.stringify(client),
+    })
+  },
+  async restoreClient() {
+    const cached = await db.queryCache.get(resolveQueryClientCacheKey())
+    if (!cached?.value) {
+      return undefined
+    }
+
+    if (typeof cached.value !== 'string') {
+      return undefined
+    }
+
+    try {
+      return JSON.parse(cached.value) as PersistedClient
+    } catch {
+      return undefined
+    }
+  },
+  async removeClient() {
+    await db.queryCache.delete(resolveQueryClientCacheKey())
+  },
+}
+
 export const queryPersister = experimental_createQueryPersister({
   // storage 对象需要实现 getItem, setItem, 和 removeItem 三个异步方法,key为用户token
   storage: {

--- a/src/app/observability/components/ErrorBoundary.tsx
+++ b/src/app/observability/components/ErrorBoundary.tsx
@@ -16,7 +16,7 @@ import {
   type VNodeChild,
 } from 'vue'
 import { $t } from '@/_utils/i18n'
-import { captureVueError } from '@/app/observability/collectors/error-collector'
+import { captureVueError } from '@/app/observability/lazy'
 import type { CapturedError, ComponentTraceItem } from './types'
 import './ErrorBoundary.css'
 

--- a/src/app/observability/components/__tests__/ErrorBoundary.spec.tsx
+++ b/src/app/observability/components/__tests__/ErrorBoundary.spec.tsx
@@ -2,14 +2,14 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent, h, nextTick } from 'vue'
 import { mount } from '@vue/test-utils'
 import ErrorBoundary from '@/app/observability/components/ErrorBoundary'
-import { captureVueError } from '@/app/observability/collectors/error-collector'
+import { captureVueError } from '@/app/observability/lazy'
 import type { FallbackSlotScope } from '@/app/observability/components/types'
 
 vi.mock('@/_utils/i18n', () => ({
   $t: (key: string) => `t:${key}`,
 }))
 
-vi.mock('@/app/observability/collectors/error-collector', () => ({
+vi.mock('@/app/observability/lazy', () => ({
   captureVueError: vi.fn(),
 }))
 
@@ -90,7 +90,11 @@ describe('ErrorBoundary', () => {
       slots: {
         default: () => h(ThrowOnce),
         fallback: ({ error, reset }: FallbackSlotScope) =>
-          h('button', { 'data-test': 'fallback-reset', onClick: reset }, `fallback-${error.message}`),
+          h(
+            'button',
+            { 'data-test': 'fallback-reset', onClick: reset },
+            `fallback-${error.message}`,
+          ),
       },
     })
 

--- a/src/app/observability/lazy.ts
+++ b/src/app/observability/lazy.ts
@@ -1,0 +1,99 @@
+import type { App } from 'vue'
+import type { InitOptions } from './index'
+import type { ErrorSeverity, ErrorSource } from './types'
+
+type ObservabilityModule = typeof import('./index')
+
+let observabilityPromise: Promise<ObservabilityModule> | null = null
+let initPromise: Promise<ObservabilityModule> | null = null
+
+const loadObservability = () => {
+  if (!observabilityPromise) {
+    observabilityPromise = import('./index')
+  }
+
+  return observabilityPromise
+}
+
+const scheduleTask = (task: () => void) => {
+  if (typeof window === 'undefined') {
+    task()
+    return
+  }
+
+  const idleWindow = window as Window & {
+    requestIdleCallback?: (
+      callback: (deadline: { didTimeout: boolean; timeRemaining: () => number }) => void,
+      options?: { timeout: number },
+    ) => number
+  }
+
+  if (typeof idleWindow.requestIdleCallback === 'function') {
+    idleWindow.requestIdleCallback(() => task(), { timeout: 2000 })
+    return
+  }
+
+  window.setTimeout(task, 0)
+}
+
+export function initObservabilityDeferred(app: App, options: InitOptions): void {
+  if (initPromise) {
+    return
+  }
+
+  initPromise = new Promise((resolve, reject) => {
+    scheduleTask(() => {
+      loadObservability()
+        .then((module) => {
+          module.initObservability(app, options)
+          resolve(module)
+        })
+        .catch((error) => {
+          initPromise = null
+          reject(error)
+        })
+    })
+  })
+}
+
+const withObservability = (callback: (module: ObservabilityModule) => void) => {
+  if (!initPromise) {
+    return
+  }
+
+  void initPromise
+    .then((module) => {
+      callback(module)
+    })
+    .catch(() => undefined)
+}
+
+export function captureError(
+  error: Error | string,
+  options: {
+    source?: ErrorSource
+    severity?: ErrorSeverity
+    traceId?: string
+    code?: number
+    httpStatus?: number
+    problemType?: string
+    context?: Record<string, unknown>
+    tags?: Record<string, string>
+  } = {},
+): void {
+  withObservability((module) => {
+    module.captureError(error, options)
+  })
+}
+
+export function capturePermissionError(action: string, subject: string, reason?: string): void {
+  withObservability((module) => {
+    module.capturePermissionError(action, subject, reason)
+  })
+}
+
+export function captureVueError(error: Error, instance: unknown, info: string): void {
+  withObservability((module) => {
+    module.captureVueError(error, instance, info)
+  })
+}

--- a/src/app/plugins/__tests__/usePlugins.spec.ts
+++ b/src/app/plugins/__tests__/usePlugins.spec.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { getInstalledPlugins, usePlugins } from '@/app/plugins/usePlugins'
-import { setupCasl } from '@/app/plugins/casl'
+import { registerPostLoginEnhancementApp } from '@/app/plugins/post-login-enhancements'
 import { useI18nPlugin } from '@/app/plugins/useI18nPlugin'
 import { usePiniaPlugin } from '@/app/plugins/usePiniaPlugin'
 import { useRequestPlugin } from '@/app/plugins/useRequestPlugin'
@@ -18,8 +18,8 @@ const { plugins, requestCallback } = vi.hoisted(() => {
   }
 })
 
-vi.mock('@/app/plugins/casl', () => ({
-  setupCasl: vi.fn(),
+vi.mock('@/app/plugins/post-login-enhancements', () => ({
+  registerPostLoginEnhancementApp: vi.fn(),
 }))
 
 vi.mock('@/app/plugins/useI18nPlugin', () => ({
@@ -52,7 +52,7 @@ describe('usePlugins', () => {
     } as never)
   })
 
-  it('installs all configured plugins and calls setupCasl', () => {
+  it('installs all configured plugins and registers app for post-login enhancements', () => {
     const app = {
       use: vi.fn(),
     }
@@ -71,7 +71,7 @@ describe('usePlugins', () => {
     expect(app.use).toHaveBeenCalledWith(plugins.request)
 
     expect(requestCallback).toHaveBeenCalledTimes(1)
-    expect(setupCasl).toHaveBeenCalledWith(app)
+    expect(registerPostLoginEnhancementApp).toHaveBeenCalledWith(app)
     expect(getInstalledPlugins().value.size).toBe(4)
   })
 
@@ -86,7 +86,7 @@ describe('usePlugins', () => {
     // 第二次调用会再次执行工厂函数，但 _usePlugin 会去重
     expect(app.use).toHaveBeenCalledTimes(4)
     expect(requestCallback).toHaveBeenCalledTimes(2)
-    expect(setupCasl).toHaveBeenCalledTimes(2)
+    expect(registerPostLoginEnhancementApp).toHaveBeenCalledTimes(2)
     expect(getInstalledPlugins().value.size).toBe(4)
   })
 })

--- a/src/app/plugins/__tests__/useRequestPlugin.spec.ts
+++ b/src/app/plugins/__tests__/useRequestPlugin.spec.ts
@@ -1,13 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { QueryClient, VueQueryPlugin } from '@tanstack/vue-query'
 import { BusinessError } from '@/modules/shared/domain/errors'
-import { useRequestPlugin } from '@/app/plugins/useRequestPlugin'
+import { enableQueryPersistence, useRequestPlugin } from '@/app/plugins/useRequestPlugin'
 import { notification, showUniqueErrorNotification } from '@/_utils/discrete_naive_api'
 import { clearQueryRequestId } from '@/app/infrastructure/query/query-request-id'
-import { queryPersister } from '@/app/infrastructure/query/tanstack_query_persist_with_dexie'
 
-const { axiosIsAxiosErrorSpy } = vi.hoisted(() => ({
+const { axiosIsAxiosErrorSpy, persistQueryClientMock } = vi.hoisted(() => ({
   axiosIsAxiosErrorSpy: vi.fn(),
+  persistQueryClientMock: vi.fn(() => [vi.fn(), Promise.resolve()]),
 }))
 
 vi.mock('axios', () => ({
@@ -32,6 +32,15 @@ vi.mock('@/app/infrastructure/query/tanstack_query_persist_with_dexie', () => ({
   queryPersister: {
     persisterFn: vi.fn(),
   },
+  queryClientPersister: {
+    persistClient: vi.fn(),
+    restoreClient: vi.fn(),
+    removeClient: vi.fn(),
+  },
+}))
+
+vi.mock('@tanstack/query-persist-client-core', () => ({
+  persistQueryClient: persistQueryClientMock,
 }))
 
 vi.mock('@/app/infrastructure/query/query-request-id', () => ({
@@ -113,7 +122,7 @@ describe('useRequestPlugin', () => {
     axiosIsAxiosErrorSpy.mockReturnValue(false)
   })
 
-  it('returns VueQueryPlugin with QueryClient and persister option', () => {
+  it('returns VueQueryPlugin with QueryClient option', () => {
     const plugins = useRequestPlugin()
 
     expect(plugins).toHaveLength(1)
@@ -121,9 +130,18 @@ describe('useRequestPlugin', () => {
     expect(plugins[0].option).toEqual(
       expect.objectContaining({
         queryClient: expect.any(QueryClient),
-        persistOptions: {
-          persister: queryPersister.persisterFn,
-        },
+      }),
+    )
+  })
+
+  it('enables persistence lazily and only once', async () => {
+    await enableQueryPersistence()
+    await enableQueryPersistence()
+
+    expect(persistQueryClientMock).toHaveBeenCalledTimes(1)
+    expect(persistQueryClientMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queryClient: expect.any(QueryClient),
       }),
     )
   })

--- a/src/app/plugins/post-login-enhancements.ts
+++ b/src/app/plugins/post-login-enhancements.ts
@@ -1,0 +1,35 @@
+import type { App } from 'vue'
+import { enableQueryPersistence } from './useRequestPlugin'
+
+let appInstance: App<Element> | null = null
+let caslEnabled = false
+let caslPromise: Promise<void> | null = null
+
+export function registerPostLoginEnhancementApp(app: App<Element>): void {
+  appInstance = app
+}
+
+async function ensureCaslEnabled(): Promise<void> {
+  if (caslEnabled || !appInstance) {
+    return
+  }
+
+  if (!caslPromise) {
+    caslPromise = import('./casl')
+      .then((module) => {
+        if (!caslEnabled && appInstance) {
+          module.setupCasl(appInstance)
+          caslEnabled = true
+        }
+      })
+      .finally(() => {
+        caslPromise = null
+      })
+  }
+
+  await caslPromise
+}
+
+export async function enablePostLoginEnhancements(): Promise<void> {
+  await Promise.allSettled([enableQueryPersistence(), ensureCaslEnabled()])
+}

--- a/src/app/plugins/usePlugins.ts
+++ b/src/app/plugins/usePlugins.ts
@@ -4,7 +4,7 @@ import { usePiniaPlugin } from './usePiniaPlugin'
 import { useRouterPlugin } from './useRouterPlugin'
 import { useRequestPlugin } from './useRequestPlugin'
 import { useI18nPlugin } from './useI18nPlugin'
-import { setupCasl } from './casl'
+import { registerPostLoginEnhancementApp } from './post-login-enhancements'
 const _installedPlugins = ref(new Set<Plugin>())
 /**
  * 注册单个Vue插件
@@ -25,6 +25,7 @@ function _usePlugin(app: App<Element>, plugin: Plugin, option?: Record<string, u
  * @param {ToBeInstalledPlugin | ToBeInstalledPlugin[] | ToBeInstalledPluginList} data 插件或插件列表
  */
 export function usePlugins(app: App<Element>): void {
+  registerPostLoginEnhancementApp(app)
   _initiation(app)
 }
 
@@ -59,7 +60,4 @@ function _initiation(app: App<Element>) {
     }
   }
   _processPlugin(data)
-
-  // 初始化 CASL 权限系统
-  setupCasl(app)
 }

--- a/src/app/plugins/useRequestPlugin.ts
+++ b/src/app/plugins/useRequestPlugin.ts
@@ -10,12 +10,11 @@ import type { ToBeInstalledPlugin } from '.'
 import { notification, showUniqueErrorNotification } from '@/_utils/discrete_naive_api'
 import { $t } from '@/_utils/i18n'
 import { match } from 'ts-pattern'
-import type { NotificationOptions } from 'naive-ui'
 import type { RFC7807Response } from '@/modules/shared/domain/response'
 import { BusinessError } from '@/modules/shared/domain/errors'
 import type { AxiosError, AxiosResponse } from 'axios'
 import axios from 'axios'
-import { queryPersister } from '@/app/infrastructure/query/tanstack_query_persist_with_dexie'
+import type { NotificationOptions as NaiveNotificationOptions } from 'naive-ui'
 import { clearQueryRequestId } from '@/app/infrastructure/query/query-request-id'
 import {
   readRequestIdFromBody,
@@ -209,11 +208,11 @@ const globalBaseErrorHandler = (
           const throwOnError = gatherStruction.meta?.toastOnError as (
             error: Error,
             query: Query<unknown, unknown, unknown> | Mutation<unknown, unknown, unknown, unknown>,
-          ) => NotificationOptions
+          ) => NaiveNotificationOptions
           showUniqueErrorNotification(errorKey, throwOnError(error, gatherStruction))
         })
         .with('object', () => {
-          const throwOnError = gatherStruction.meta?.toastOnError as NotificationOptions
+          const throwOnError = gatherStruction.meta?.toastOnError as NaiveNotificationOptions
           showUniqueErrorNotification(errorKey, throwOnError)
         })
         .otherwise(() => {
@@ -266,11 +265,11 @@ const globalSuccessHandler = (
         const toastOnSuccess = gatherStruction.meta?.toastOnSuccess as (
           data: RFC7807Response<unknown> | AxiosResponse<RFC7807Response<unknown>>,
           query: Query<unknown, unknown, unknown> | Mutation<unknown, unknown, unknown, unknown>,
-        ) => NotificationOptions
+        ) => NaiveNotificationOptions
         notification.success(toastOnSuccess(data, gatherStruction))
       })
       .with('object', () => {
-        const toastOnSuccess = gatherStruction.meta?.toastOnSuccess as NotificationOptions
+        const toastOnSuccess = gatherStruction.meta?.toastOnSuccess as NaiveNotificationOptions
         notification.success(toastOnSuccess)
       })
       .otherwise(() => {
@@ -316,6 +315,37 @@ const queryClient = new QueryClient({
   }),
 })
 
+let queryPersistenceEnabled = false
+let queryPersistencePromise: Promise<void> | null = null
+
+export function enableQueryPersistence(): Promise<void> {
+  if (queryPersistenceEnabled) {
+    return Promise.resolve()
+  }
+
+  if (!queryPersistencePromise) {
+    queryPersistencePromise = Promise.all([
+      import('@tanstack/query-persist-client-core'),
+      import('@/app/infrastructure/query/tanstack_query_persist_with_dexie'),
+    ])
+      .then(async ([persistModule, persisterModule]) => {
+        const [, restorePromise] = persistModule.persistQueryClient({
+          queryClient,
+          persister: persisterModule.queryClientPersister,
+        })
+
+        await restorePromise
+        queryPersistenceEnabled = true
+      })
+      .catch((error) => {
+        queryPersistencePromise = null
+        throw error
+      })
+  }
+
+  return queryPersistencePromise
+}
+
 /**
  * 初始化TanStack Query
  */
@@ -325,9 +355,6 @@ export function useRequestPlugin(): ToBeInstalledPlugin[] {
       plugin: VueQueryPlugin,
       option: {
         queryClient,
-        persistOptions: {
-          persister: queryPersister.persisterFn,
-        },
       },
     },
   ]

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,14 +1,18 @@
 import { createApp } from 'vue'
 import '@/app/presentation/theme/styles/token.css'
 import { usePlugins } from '@/app/plugins/usePlugins.ts'
-import { initObservability } from '@/app/observability'
-import { initAuthTokenLifecycle } from '@/modules/access/application/token-manager'
+import { enablePostLoginEnhancements } from '@/app/plugins/post-login-enhancements'
+import { initObservabilityDeferred } from '@/app/observability/lazy'
+import {
+  getStoredAccessToken,
+  initAuthTokenLifecycle,
+} from '@/modules/access/application/token-manager'
 import App from './App.vue'
 
 const app = createApp(App)
 
 // 初始化可观测性体系（需在 plugins 之前，尽早捕获错误）
-initObservability(app, {
+initObservabilityDeferred(app, {
   observability: {
     // 可选：覆盖默认配置
     // otelEndpoint: import.meta.env.VITE_OTEL_ENDPOINT,
@@ -24,5 +28,9 @@ initObservability(app, {
 
 usePlugins(app)
 initAuthTokenLifecycle()
+
+if (getStoredAccessToken()) {
+  void enablePostLoginEnhancements().catch(() => undefined)
+}
 
 app.mount('#app')

--- a/src/modules/access/presentation/directives/__tests__/can.spec.ts
+++ b/src/modules/access/presentation/directives/__tests__/can.spec.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { DirectiveBinding } from 'vue'
 import canDirective from '@/modules/access/presentation/directives/can'
 import { ability } from '@/modules/access/application/ability'
-import { capturePermissionError } from '@/app/observability'
+import { capturePermissionError } from '@/app/observability/lazy'
 
 vi.mock('@/modules/access/application/ability', () => ({
   ability: {
@@ -10,22 +10,20 @@ vi.mock('@/modules/access/application/ability', () => ({
   },
 }))
 
-vi.mock('@/app/observability', () => ({
+vi.mock('@/app/observability/lazy', () => ({
   capturePermissionError: vi.fn(),
 }))
 
-const makeBinding = (
-  value: string | string[],
-  arg?: string,
-): DirectiveBinding<string | string[]> =>
+const makeBinding = (value: string | string[], arg?: string): DirectiveBinding<string | string[]> =>
   ({
     value,
     arg,
   }) as DirectiveBinding<string | string[]>
 
-const createMockEl = () => ({
-  remove: vi.fn(),
-}) as unknown as HTMLElement
+const createMockEl = () =>
+  ({
+    remove: vi.fn(),
+  }) as unknown as HTMLElement
 
 type CanDirectiveHooks = {
   mounted?: (el: HTMLElement, binding: DirectiveBinding<string | string[]>) => void
@@ -64,7 +62,9 @@ describe('v-can directive', () => {
   })
 
   it('uses AND logic for permission arrays by default', () => {
-    vi.mocked(ability.can).mockImplementation((action, subject) => action === 'read' && subject === 'User')
+    vi.mocked(ability.can).mockImplementation(
+      (action, subject) => action === 'read' && subject === 'User',
+    )
 
     const el = createMockEl()
 
@@ -79,7 +79,9 @@ describe('v-can directive', () => {
   })
 
   it('uses OR logic when arg is any', () => {
-    vi.mocked(ability.can).mockImplementation((action, subject) => action === 'read' && subject === 'User')
+    vi.mocked(ability.can).mockImplementation(
+      (action, subject) => action === 'read' && subject === 'User',
+    )
 
     const el = createMockEl()
 

--- a/src/modules/access/presentation/directives/can.ts
+++ b/src/modules/access/presentation/directives/can.ts
@@ -10,7 +10,7 @@
 
 import type { Directive, DirectiveBinding } from 'vue'
 import { ability, type Action, type Subject } from '../../application/ability'
-import { capturePermissionError } from '@/app/observability'
+import { capturePermissionError } from '@/app/observability/lazy'
 
 interface PermissionValue {
   action: Action

--- a/src/modules/user/application/hooks/__tests__/auth-hooks.spec.ts
+++ b/src/modules/user/application/hooks/__tests__/auth-hooks.spec.ts
@@ -55,6 +55,10 @@ vi.mock('@/modules/user/infrastructure/oauth-endpoints', () => ({
   buildOauth2AuthorizationUrl: vi.fn((platform: string) => `https://oauth.example/${platform}`),
 }))
 
+vi.mock('@/app/plugins/post-login-enhancements', () => ({
+  enablePostLoginEnhancements: vi.fn(() => Promise.resolve()),
+}))
+
 vi.mock('@/_utils/discrete_naive_api', () => ({
   message: {
     success: discreteMessageSuccessSpy,

--- a/src/modules/user/application/hooks/useLogin.ts
+++ b/src/modules/user/application/hooks/useLogin.ts
@@ -1,10 +1,14 @@
-import type { SignInForm, SignInResponse, SignInResponseComplete } from '@/modules/user/application/models'
+import type {
+  SignInForm,
+  SignInResponse,
+  SignInResponseComplete,
+} from '@/modules/user/application/models'
 import { useMutation } from '@tanstack/vue-query'
 import type { AxiosError } from 'axios'
 import { userService } from '@/modules/user/application/service'
-import { useAccountStore } from '@/modules/user/application/stores/useAccountStore.ts'
 import router from '@/router'
 import type { RouteLocationRaw } from 'vue-router'
+import { enablePostLoginEnhancements } from '@/app/plugins/post-login-enhancements'
 
 export type SignInMutate = { redirect?: RouteLocationRaw } & (
   | {
@@ -60,16 +64,18 @@ export function useLogin() {
           query: {
             token: data.twoFactorToken,
             rememberMe,
-            redirect: typeof variable.redirect === 'string'
-              ? variable.redirect
-              : undefined,
+            redirect: typeof variable.redirect === 'string' ? variable.redirect : undefined,
           },
         })
         return
       }
 
       const complete = data as SignInResponseComplete
+      const { useAccountStore } = await import(
+        '@/modules/user/application/stores/useAccountStore.ts'
+      )
       useAccountStore().login(complete)
+      void enablePostLoginEnhancements().catch(() => undefined)
       router.push(variable.redirect || { name: 'dashboard' })
     },
   })

--- a/src/router/guards/SetupAbilityGuard.ts
+++ b/src/router/guards/SetupAbilityGuard.ts
@@ -30,7 +30,7 @@
 
 import type { Router } from 'vue-router'
 import { ability, type Action, type Subject } from '@/modules/access/application/ability'
-import { capturePermissionError } from '@/app/observability'
+import { capturePermissionError } from '@/app/observability/lazy'
 
 export interface AbilityRule {
   action: Action

--- a/src/router/guards/SetupAuthGuard.ts
+++ b/src/router/guards/SetupAuthGuard.ts
@@ -12,11 +12,8 @@ import { enablePostLoginEnhancements } from '@/app/plugins/post-login-enhancemen
 
 type AuthGuardDependencies = {
   useAccountStore: typeof import('@/modules/user/application/stores/useAccountStore').useAccountStore
-  useQueryClient: typeof import('@tanstack/vue-query').useQueryClient
-  userKeys: typeof import('@/modules/user/application/hooks/useLoadUserInfo').userKeys
   userService: typeof import('@/modules/user/application/service').userService
   axios: typeof import('axios').default
-  withQueryRequestContext: typeof import('@/app/infrastructure/query/query-request-context').withQueryRequestContext
   ResponseCode: typeof import('@/modules/shared/application/constants/response-code').ResponseCode
 }
 
@@ -26,48 +23,22 @@ const loadAuthGuardDependencies = (): Promise<AuthGuardDependencies> => {
   if (!authGuardDependenciesPromise) {
     authGuardDependenciesPromise = Promise.all([
       import('@/modules/user/application/stores/useAccountStore'),
-      import('@tanstack/vue-query'),
-      import('@/modules/user/application/hooks/useLoadUserInfo'),
       import('@/modules/user/application/service'),
       import('axios'),
-      import('@/app/infrastructure/query/query-request-context'),
       import('@/modules/shared/application/constants/response-code'),
-    ]).then(
-      ([
-        storeModule,
-        queryModule,
-        userInfoModule,
-        userServiceModule,
-        axiosModule,
-        contextModule,
-        codeModule,
-      ]) => ({
-        useAccountStore: storeModule.useAccountStore,
-        useQueryClient: queryModule.useQueryClient,
-        userKeys: userInfoModule.userKeys,
-        userService: userServiceModule.userService,
-        axios: axiosModule.default,
-        withQueryRequestContext: contextModule.withQueryRequestContext,
-        ResponseCode: codeModule.ResponseCode,
-      }),
-    )
+    ]).then(([storeModule, userServiceModule, axiosModule, codeModule]) => ({
+      useAccountStore: storeModule.useAccountStore,
+      userService: userServiceModule.userService,
+      axios: axiosModule.default,
+      ResponseCode: codeModule.ResponseCode,
+    }))
   }
 
   return authGuardDependenciesPromise
 }
 
-const loadCurrentUserInfo = async (
-  accessToken: string,
-  deps: AuthGuardDependencies,
-): Promise<SignInResponse> => {
-  const queryClient = deps.useQueryClient()
-
-  return queryClient.ensureQueryData({
-    queryKey: deps.userKeys.INFO(accessToken),
-    queryFn: (ctx) =>
-      deps.withQueryRequestContext(ctx.queryKey, ctx, () => deps.userService.getCurrentUserInfo()),
-    staleTime: 1000 * 60 * 5,
-  }) as Promise<SignInResponse>
+const loadCurrentUserInfo = async (deps: AuthGuardDependencies): Promise<SignInResponse> => {
+  return deps.userService.getCurrentUserInfo() as Promise<SignInResponse>
 }
 
 const mergeStoredRefreshToken = (data: SignInResponse): SignInResponseComplete => {
@@ -100,7 +71,7 @@ const isAuthError = (error: unknown, deps: AuthGuardDependencies): boolean => {
       ) {
         return true
       }
-      return bizError.status === 401 || bizError.status === 403
+      return bizError.status === 401
     }
   }
 
@@ -110,7 +81,6 @@ const isAuthError = (error: unknown, deps: AuthGuardDependencies): boolean => {
     const code = payload?.code
     return (
       status === 401 ||
-      status === 403 ||
       code === deps.ResponseCode.OAUTH2_TOKEN_VERIFY_ERROR ||
       code === deps.ResponseCode.OAUTH2_TOKEN_EXPIRED
     )
@@ -118,6 +88,8 @@ const isAuthError = (error: unknown, deps: AuthGuardDependencies): boolean => {
 
   return false
 }
+
+const ERROR_ROUTE_NAMES = new Set(['403', '404', '500'])
 
 export function setupAuthGuards(router: Router) {
   router.beforeEach(async (to) => {
@@ -150,7 +122,11 @@ export function setupAuthGuards(router: Router) {
       return { name: 'login', query: { redirect: to.fullPath } }
     }
 
-    if (!requiresAuth && to.name !== 'oauth2-callback') {
+    if (
+      !requiresAuth &&
+      to.name !== 'oauth2-callback' &&
+      !ERROR_ROUTE_NAMES.has(String(to.name ?? ''))
+    ) {
       void enablePostLoginEnhancements().catch(() => undefined)
       return { name: 'dashboard' }
     }
@@ -158,11 +134,9 @@ export function setupAuthGuards(router: Router) {
     const deps = await loadAuthGuardDependencies()
     const accountStore = deps.useAccountStore()
 
-    void enablePostLoginEnhancements().catch(() => undefined)
-
     if (!accountStore.isLoadedData) {
       try {
-        const data = await loadCurrentUserInfo(token, deps)
+        const data = await loadCurrentUserInfo(deps)
         accountStore.login(mergeStoredRefreshToken(data))
       } catch (error) {
         captureError(error as Error, {
@@ -177,6 +151,11 @@ export function setupAuthGuards(router: Router) {
           accountStore.clearSession()
           return { name: 'login', query: { redirect: to.fullPath } }
         }
+
+        if (ERROR_ROUTE_NAMES.has(String(to.name ?? ''))) {
+          return true
+        }
+
         return { name: '500' }
       }
     }
@@ -186,9 +165,8 @@ export function setupAuthGuards(router: Router) {
     }
 
     const requirePerms = to.meta.permissions
-    const requireRoles = to.meta.roles
 
-    if (!requirePerms && !requireRoles) {
+    if (!requirePerms) {
       return true
     }
 
@@ -208,21 +186,7 @@ export function setupAuthGuards(router: Router) {
       }
     }
 
-    if (requireRoles) {
-      const hasAllRoles = requireRoles.every((role) => accountStore.hasRole(role))
-      if (!hasAllRoles) {
-        captureError(new Error('Role denied'), {
-          source: 'permission',
-          severity: 'warning',
-          context: {
-            route: to.name,
-            requiredRoles: requireRoles,
-            userRoles: accountStore.roleList.map((item) => item.name),
-          },
-        })
-        return { name: '403' }
-      }
-    }
+    void enablePostLoginEnhancements().catch(() => undefined)
 
     return true
   })

--- a/src/router/guards/SetupAuthGuard.ts
+++ b/src/router/guards/SetupAuthGuard.ts
@@ -1,14 +1,6 @@
-import { userKeys } from '@/modules/user/application/hooks/useLoadUserInfo'
-import { useAccountStore } from '@/modules/user/application/stores/useAccountStore'
 import type { Router } from 'vue-router'
-import { useQueryClient } from '@tanstack/vue-query'
 import type { SignInResponse, SignInResponseComplete } from '@/modules/user/application/models'
-import { userService } from '@/modules/user/application/service'
-import axios from 'axios'
-import type { AxiosError } from 'axios'
-import { captureError } from '@/app/observability'
-import { withQueryRequestContext } from '@/app/infrastructure/query/query-request-context'
-import { ResponseCode } from '@/modules/shared/application/constants/response-code'
+import { captureError } from '@/app/observability/lazy'
 import {
   forceRefreshAccessToken,
   getStoredAccessToken,
@@ -16,15 +8,66 @@ import {
   hasStoredRefreshToken,
   isLogoutInProgress,
 } from '@/modules/access/application/token-manager'
+import { enablePostLoginEnhancements } from '@/app/plugins/post-login-enhancements'
 
-const loadCurrentUserInfo = async (accessToken: string): Promise<SignInResponse> => {
-  const queryClient = useQueryClient()
-  return queryClient.ensureQueryData<SignInResponse, AxiosError<unknown>>({
-    queryKey: userKeys.INFO(accessToken),
+type AuthGuardDependencies = {
+  useAccountStore: typeof import('@/modules/user/application/stores/useAccountStore').useAccountStore
+  useQueryClient: typeof import('@tanstack/vue-query').useQueryClient
+  userKeys: typeof import('@/modules/user/application/hooks/useLoadUserInfo').userKeys
+  userService: typeof import('@/modules/user/application/service').userService
+  axios: typeof import('axios').default
+  withQueryRequestContext: typeof import('@/app/infrastructure/query/query-request-context').withQueryRequestContext
+  ResponseCode: typeof import('@/modules/shared/application/constants/response-code').ResponseCode
+}
+
+let authGuardDependenciesPromise: Promise<AuthGuardDependencies> | null = null
+
+const loadAuthGuardDependencies = (): Promise<AuthGuardDependencies> => {
+  if (!authGuardDependenciesPromise) {
+    authGuardDependenciesPromise = Promise.all([
+      import('@/modules/user/application/stores/useAccountStore'),
+      import('@tanstack/vue-query'),
+      import('@/modules/user/application/hooks/useLoadUserInfo'),
+      import('@/modules/user/application/service'),
+      import('axios'),
+      import('@/app/infrastructure/query/query-request-context'),
+      import('@/modules/shared/application/constants/response-code'),
+    ]).then(
+      ([
+        storeModule,
+        queryModule,
+        userInfoModule,
+        userServiceModule,
+        axiosModule,
+        contextModule,
+        codeModule,
+      ]) => ({
+        useAccountStore: storeModule.useAccountStore,
+        useQueryClient: queryModule.useQueryClient,
+        userKeys: userInfoModule.userKeys,
+        userService: userServiceModule.userService,
+        axios: axiosModule.default,
+        withQueryRequestContext: contextModule.withQueryRequestContext,
+        ResponseCode: codeModule.ResponseCode,
+      }),
+    )
+  }
+
+  return authGuardDependenciesPromise
+}
+
+const loadCurrentUserInfo = async (
+  accessToken: string,
+  deps: AuthGuardDependencies,
+): Promise<SignInResponse> => {
+  const queryClient = deps.useQueryClient()
+
+  return queryClient.ensureQueryData({
+    queryKey: deps.userKeys.INFO(accessToken),
     queryFn: (ctx) =>
-      withQueryRequestContext(ctx.queryKey, ctx, () => userService.getCurrentUserInfo()),
+      deps.withQueryRequestContext(ctx.queryKey, ctx, () => deps.userService.getCurrentUserInfo()),
     staleTime: 1000 * 60 * 5,
-  })
+  }) as Promise<SignInResponse>
 }
 
 const mergeStoredRefreshToken = (data: SignInResponse): SignInResponseComplete => {
@@ -47,54 +90,39 @@ const mergeStoredRefreshToken = (data: SignInResponse): SignInResponseComplete =
   }
 }
 
-const isAuthError = (error: unknown): boolean => {
+const isAuthError = (error: unknown, deps: AuthGuardDependencies): boolean => {
   if (error && typeof error === 'object' && 'isBusinessError' in error) {
     const bizError = error as { isBusinessError?: boolean; code?: number; status?: number }
     if (bizError.isBusinessError) {
-      if (bizError.code === ResponseCode.OAUTH2_TOKEN_VERIFY_ERROR ||
-          bizError.code === ResponseCode.OAUTH2_TOKEN_EXPIRED) {
+      if (
+        bizError.code === deps.ResponseCode.OAUTH2_TOKEN_VERIFY_ERROR ||
+        bizError.code === deps.ResponseCode.OAUTH2_TOKEN_EXPIRED
+      ) {
         return true
       }
       return bizError.status === 401 || bizError.status === 403
     }
   }
 
-  if (axios.isAxiosError(error)) {
+  if (deps.axios.isAxiosError(error)) {
     const status = error.response?.status
     const payload = error.response?.data as { code?: number } | undefined
     const code = payload?.code
-    return status === 401 || status === 403 ||
-      code === ResponseCode.OAUTH2_TOKEN_VERIFY_ERROR ||
-      code === ResponseCode.OAUTH2_TOKEN_EXPIRED
+    return (
+      status === 401 ||
+      status === 403 ||
+      code === deps.ResponseCode.OAUTH2_TOKEN_VERIFY_ERROR ||
+      code === deps.ResponseCode.OAUTH2_TOKEN_EXPIRED
+    )
   }
 
   return false
 }
 
-/**
- * 认证守卫
- *
- * 职责：
- * 1. 检查用户是否已登录
- * 2. 加载用户数据（首次）
- * 3. 处理登录重定向
- *
- * 注意：
- * - 权限检查由 SetupAbilityGuard 负责
- * - 此守卫只负责认证（Authentication），不负责授权（Authorization）
- */
 export function setupAuthGuards(router: Router) {
   router.beforeEach(async (to) => {
-    const accountStore = useAccountStore()
+    const requiresAuth = to.meta.requiresAuth !== false
 
-    // ==============================================
-    // 1. 检查路由是否需要认证
-    // ==============================================
-    const requiresAuth = to.meta.requiresAuth !== false // 默认需要认证
-
-    // ==============================================
-    // 2. 预处理 token（优先走 refreshToken）
-    // ==============================================
     let token = getStoredAccessToken()
     const canRefresh = hasStoredRefreshToken()
     const loggingOut = isLogoutInProgress()
@@ -115,36 +143,28 @@ export function setupAuthGuards(router: Router) {
       }
     }
 
-    // ==============================================
-    // 3. 没有 Token 的情况
-    // ==============================================
     if (!token) {
-      // 如果路由不需要认证，放行
       if (!requiresAuth) {
         return true
       }
-      // 否则，重定向到登录页
       return { name: 'login', query: { redirect: to.fullPath } }
     }
 
-    // ==============================================
-    // 4. 有 Token 的情况
-    // ==============================================
-
-    // 4.1 已登录用户访问登录页，重定向到 Dashboard
-    // 特殊情况：oauth2-callback 需要放行
     if (!requiresAuth && to.name !== 'oauth2-callback') {
+      void enablePostLoginEnhancements().catch(() => undefined)
       return { name: 'dashboard' }
     }
 
-    // 4.2 数据预加载（首次登录时）
-    // 只有在数据还没加载过时才等待，后续路由跳转不会阻塞
+    const deps = await loadAuthGuardDependencies()
+    const accountStore = deps.useAccountStore()
+
+    void enablePostLoginEnhancements().catch(() => undefined)
+
     if (!accountStore.isLoadedData) {
       try {
-        const data = await loadCurrentUserInfo(token)
+        const data = await loadCurrentUserInfo(token, deps)
         accountStore.login(mergeStoredRefreshToken(data))
       } catch (error) {
-        // useRequest 已内置 401 -> refresh -> 重放，守卫不再重复触发 refresh
         captureError(error as Error, {
           source: 'http',
           severity: 'error',
@@ -153,7 +173,7 @@ export function setupAuthGuards(router: Router) {
             action: 'loadUserInfo',
           },
         })
-        if (isAuthError(error)) {
+        if (isAuthError(error, deps)) {
           accountStore.clearSession()
           return { name: 'login', query: { redirect: to.fullPath } }
         }
@@ -161,30 +181,19 @@ export function setupAuthGuards(router: Router) {
       }
     }
 
-    // ==============================================
-    // 5. 权限检查
-    // ==============================================
-
-    // 如果路由定义了 CASL ability 规则，跳过旧的权限检查
-    // 权限检查由 SetupAbilityGuard 统一处理
     if (to.meta.ability) {
       return true
     }
 
-    // 兼容旧的权限检查方式（permissions/roles）
     const requirePerms = to.meta.permissions
     const requireRoles = to.meta.roles
 
-    // 如果该路由不需要任何权限，直接放行
     if (!requirePerms && !requireRoles) {
       return true
     }
 
-    // 校验权限
     if (requirePerms) {
-      const hasAllPerms = requirePerms.every((perm) =>
-        accountStore.hasPermission(perm)
-      )
+      const hasAllPerms = requirePerms.every((perm) => accountStore.hasPermission(perm))
       if (!hasAllPerms) {
         captureError(new Error('Permission denied'), {
           source: 'permission',
@@ -199,11 +208,8 @@ export function setupAuthGuards(router: Router) {
       }
     }
 
-    // 校验角色
     if (requireRoles) {
-      const hasAllRoles = requireRoles.every((role) =>
-        accountStore.hasRole(role)
-      )
+      const hasAllRoles = requireRoles.every((role) => accountStore.hasRole(role))
       if (!hasAllRoles) {
         captureError(new Error('Role denied'), {
           source: 'permission',

--- a/src/router/guards/__tests__/SetupAbilityGuard.spec.ts
+++ b/src/router/guards/__tests__/SetupAbilityGuard.spec.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { setupAbilityGuard } from '@/router/guards/SetupAbilityGuard'
 import { ability } from '@/modules/access/application/ability'
-import { capturePermissionError } from '@/app/observability'
+import { capturePermissionError } from '@/app/observability/lazy'
 
 vi.mock('@/modules/access/application/ability', () => ({
   ability: {
@@ -9,7 +9,7 @@ vi.mock('@/modules/access/application/ability', () => ({
   },
 }))
 
-vi.mock('@/app/observability', () => ({
+vi.mock('@/app/observability/lazy', () => ({
   capturePermissionError: vi.fn(),
 }))
 

--- a/src/router/guards/__tests__/SetupAuthGuard.spec.ts
+++ b/src/router/guards/__tests__/SetupAuthGuard.spec.ts
@@ -8,7 +8,8 @@ import {
   isLogoutInProgress,
 } from '@/modules/access/application/token-manager'
 import { useAccountStore } from '@/modules/user/application/stores/useAccountStore'
-import { captureError } from '@/app/observability'
+import { captureError } from '@/app/observability/lazy'
+import { enablePostLoginEnhancements } from '@/app/plugins/post-login-enhancements'
 
 vi.mock('@/modules/access/application/token-manager', () => ({
   forceRefreshAccessToken: vi.fn(),
@@ -22,8 +23,12 @@ vi.mock('@/modules/user/application/stores/useAccountStore', () => ({
   useAccountStore: vi.fn(),
 }))
 
-vi.mock('@/app/observability', () => ({
+vi.mock('@/app/observability/lazy', () => ({
   captureError: vi.fn(),
+}))
+
+vi.mock('@/app/plugins/post-login-enhancements', () => ({
+  enablePostLoginEnhancements: vi.fn(() => Promise.resolve()),
 }))
 
 type GuardTo = {
@@ -78,6 +83,7 @@ describe('setupAuthGuards', () => {
       accessToken: 'access-refreshed',
       refreshToken: 'refresh-refreshed',
     })
+    vi.mocked(enablePostLoginEnhancements).mockResolvedValue()
   })
 
   it('redirects to login when auth is required and token missing', async () => {

--- a/src/router/guards/__tests__/SetupAuthGuard.spec.ts
+++ b/src/router/guards/__tests__/SetupAuthGuard.spec.ts
@@ -8,6 +8,8 @@ import {
   isLogoutInProgress,
 } from '@/modules/access/application/token-manager'
 import { useAccountStore } from '@/modules/user/application/stores/useAccountStore'
+import { userService } from '@/modules/user/application/service'
+import type { SignInResponseComplete } from '@/modules/user/application/models'
 import { captureError } from '@/app/observability/lazy'
 import { enablePostLoginEnhancements } from '@/app/plugins/post-login-enhancements'
 
@@ -21,6 +23,12 @@ vi.mock('@/modules/access/application/token-manager', () => ({
 
 vi.mock('@/modules/user/application/stores/useAccountStore', () => ({
   useAccountStore: vi.fn(),
+}))
+
+vi.mock('@/modules/user/application/service', () => ({
+  userService: {
+    getCurrentUserInfo: vi.fn(),
+  },
 }))
 
 vi.mock('@/app/observability/lazy', () => ({
@@ -38,7 +46,6 @@ type GuardTo = {
     requiresAuth?: boolean
     ability?: unknown
     permissions?: string[]
-    roles?: string[]
   }
 }
 
@@ -54,6 +61,23 @@ const createAccountStore = () => ({
   hasRole: vi.fn((role: string) => role === 'role.admin'),
   permissionList: [{ name: 'perm.read' }],
   roleList: [{ name: 'role.admin' }],
+})
+
+const createSignInResponse = (): SignInResponseComplete => ({
+  requireTwoFactor: false,
+  user: {
+    id: 1,
+    name: 'Tester',
+    phone: '13800000000',
+    active: '1',
+    isDeleted: 0,
+    platform: 'NATIVE',
+  },
+  profile: null,
+  token: 'access-token',
+  refreshToken: 'refresh-token',
+  permissionList: [],
+  roleList: [],
 })
 
 const setupGuard = () => {
@@ -83,6 +107,7 @@ describe('setupAuthGuards', () => {
       accessToken: 'access-refreshed',
       refreshToken: 'refresh-refreshed',
     })
+    vi.mocked(userService.getCurrentUserInfo).mockResolvedValue(createSignInResponse())
     vi.mocked(enablePostLoginEnhancements).mockResolvedValue()
   })
 
@@ -150,6 +175,26 @@ describe('setupAuthGuards', () => {
     expect(result).toBe(true)
   })
 
+  it('loads current user info without passing explicit access token during bootstrap', async () => {
+    vi.mocked(getStoredAccessToken).mockReturnValue('access-token')
+
+    const accountStore = createAccountStore()
+    accountStore.isLoadedData = false
+    vi.mocked(useAccountStore).mockReturnValue(accountStore as never)
+
+    const { guard } = setupGuard()
+    const result = await guard({
+      name: 'dashboard',
+      fullPath: '/dashboard',
+      meta: {},
+    })
+
+    expect(userService.getCurrentUserInfo).toHaveBeenCalledTimes(1)
+    expect(userService.getCurrentUserInfo).toHaveBeenCalledWith()
+    expect(accountStore.login).toHaveBeenCalledTimes(1)
+    expect(result).toBe(true)
+  })
+
   it('skips refresh workflow when logout is in progress', async () => {
     vi.mocked(isLogoutInProgress).mockReturnValue(true)
     vi.mocked(getStoredAccessToken).mockReturnValue('access-token')
@@ -181,7 +226,6 @@ describe('setupAuthGuards', () => {
           subject: 'Approval',
         },
         permissions: ['perm.denied'],
-        roles: ['role.denied'],
       },
     })
 
@@ -210,23 +254,21 @@ describe('setupAuthGuards', () => {
     expect(captureError).toHaveBeenCalled()
   })
 
-  it('returns 403 when legacy roles check fails', async () => {
+  it('allows route when no permissions are configured', async () => {
     vi.mocked(getStoredAccessToken).mockReturnValue('access-token')
 
     const accountStore = createAccountStore()
-    accountStore.hasRole.mockReturnValue(false)
     vi.mocked(useAccountStore).mockReturnValue(accountStore as never)
 
     const { guard } = setupGuard()
     const result = await guard({
       name: 'approval-process-list',
       fullPath: '/approval/process/list',
-      meta: {
-        roles: ['role.reviewer'],
-      },
+      meta: {},
     })
 
-    expect(result).toEqual({ name: '403' })
-    expect(captureError).toHaveBeenCalled()
+    expect(result).toBe(true)
+    expect(accountStore.hasRole).not.toHaveBeenCalled()
+    expect(captureError).not.toHaveBeenCalled()
   })
 })

--- a/src/router/modules/approval.routes.ts
+++ b/src/router/modules/approval.routes.ts
@@ -1,4 +1,5 @@
 import type { AppRouteRecord } from '../types'
+import DashboardView from '@/views/auth/DashboardView.vue'
 
 /**
  * 审批中心相关路由
@@ -7,7 +8,7 @@ export const approvalRoutes: AppRouteRecord[] = [
   {
     path: '/approval',
     name: 'approval',
-    component: () => import('@/views/auth/DashboardView.vue'),
+    component: DashboardView,
     meta: {
       name: 'layout.menu.approval',
       icon: 'ApprovalsApp16Regular',
@@ -38,7 +39,7 @@ export const approvalRoutes: AppRouteRecord[] = [
   {
     path: '/approval/my-task/list',
     name: 'approval-my-task-list',
-    component: () => import('@/views/auth/DashboardView.vue'),
+    component: DashboardView,
     meta: {
       name: 'layout.menu.reviewing',
       icon: 'TaskComplete',
@@ -48,7 +49,7 @@ export const approvalRoutes: AppRouteRecord[] = [
   {
     path: '/approval/process/list',
     name: 'approval-process-list',
-    component: () => import('@/views/auth/DashboardView.vue'),
+    component: DashboardView,
     meta: {
       name: 'layout.menu.process',
       icon: 'Fluid20Regular',
@@ -58,7 +59,7 @@ export const approvalRoutes: AppRouteRecord[] = [
   {
     path: '/approval/node/list',
     name: 'approval-node-list',
-    component: () => import('@/views/auth/DashboardView.vue'),
+    component: DashboardView,
     meta: {
       name: 'layout.menu.nodes',
       icon: 'NodeIndexOutlined',
@@ -69,7 +70,7 @@ export const approvalRoutes: AppRouteRecord[] = [
   {
     path: '/approval/task/list',
     name: 'approval-task-list',
-    component: () => import('@/views/auth/DashboardView.vue'),
+    component: DashboardView,
     meta: {
       name: 'layout.menu.tasks',
       icon: 'FeaturedPlayListOutlined',

--- a/src/router/modules/business.routes.ts
+++ b/src/router/modules/business.routes.ts
@@ -1,5 +1,6 @@
 import type { AppRouteRecord } from '../types'
 import type { RouteLocation } from 'vue-router'
+import DashboardView from '@/views/auth/DashboardView.vue'
 
 // 工具函数
 const toNumberOrNull = (val: unknown): number | null => {
@@ -16,7 +17,7 @@ export const businessRoutes: AppRouteRecord[] = [
   {
     path: '/business',
     name: 'business',
-    component: () => import('@/views/auth/DashboardView.vue'),
+    component: DashboardView,
     meta: {
       name: 'layout.menu.business',
       icon: 'BusinessCenterOutlined',

--- a/src/router/modules/dashboard.routes.ts
+++ b/src/router/modules/dashboard.routes.ts
@@ -23,7 +23,7 @@ export const dashboardRoutes: AppRouteRecord[] = [
   {
     path: '/document',
     name: 'document',
-    component: () => import('@/views/auth/DashboardView.vue'),
+    component: DashboardView,
     meta: {
       name: 'layout.menu.docs',
       icon: 'MenuBookTwotone',

--- a/src/router/modules/manage.routes.ts
+++ b/src/router/modules/manage.routes.ts
@@ -1,5 +1,6 @@
 import type { AppRouteRecord } from '../types'
 import type { RouteLocation } from 'vue-router'
+import DashboardView from '@/views/auth/DashboardView.vue'
 
 const toNumberOrNull = (val: unknown): number | null => {
   if (val === null || val === undefined || val === '') return null
@@ -14,7 +15,7 @@ export const manageRoutes: AppRouteRecord[] = [
   {
     path: '/manage',
     name: 'manage',
-    component: () => import('@/views/auth/DashboardView.vue'),
+    component: DashboardView,
     meta: {
       name: 'layout.menu.manage',
       icon: 'ManageAccountsOutlined',

--- a/src/router/modules/user.routes.ts
+++ b/src/router/modules/user.routes.ts
@@ -1,4 +1,5 @@
 import type { AppRouteRecord } from '../types'
+import DashboardView from '@/views/auth/DashboardView.vue'
 
 /**
  * 用户中心相关路由
@@ -7,7 +8,7 @@ export const userRoutes: AppRouteRecord[] = [
   {
     path: '/user',
     name: 'user',
-    component: () => import('@/views/auth/DashboardView.vue'),
+    component: DashboardView,
     meta: {
       name: 'layout.menu.profile',
       icon: 'UserSwitchOutlined',
@@ -61,7 +62,7 @@ export const userRoutes: AppRouteRecord[] = [
   {
     path: '/user/agent/list',
     name: 'user-agent-list',
-    component: () => import('@/views/auth/DashboardView.vue'),
+    component: DashboardView,
     meta: {
       name: 'layout.menu.agents',
       icon: 'RealEstateAgentOutlined',
@@ -71,7 +72,7 @@ export const userRoutes: AppRouteRecord[] = [
   {
     path: '/sign/self/list',
     name: 'my-sign',
-    component: () => import('@/views/auth/DashboardView.vue'),
+    component: DashboardView,
     meta: {
       name: 'layout.menu.mySign',
       icon: 'AssignmentIndOutlined',

--- a/src/types/vendor/vue-query.d.ts
+++ b/src/types/vendor/vue-query.d.ts
@@ -2,7 +2,7 @@ import '@tanstack/vue-query'
 // 从库中导入基础类型，以便在声明中使用
 import type { Query, Mutation, QueryKey } from '@tanstack/vue-query'
 import type { AxiosError } from 'axios'
-import type { NotificationOptions } from 'naive-ui'
+import type { NotificationOptions as NaiveNotificationOptions } from 'naive-ui'
 import type { ServerResponse } from '../request'
 
 // 为 TanStack Query 的泛型定义一些别名，使其更清晰
@@ -29,16 +29,16 @@ declare module '@tanstack/vue-query' {
       | ((
           error: TError,
           query: Query<TQueryFnData, TError, TData, TQueryKey>,
-        ) => NotificationOptions | string)
-      | NotificationOptions
+        ) => NaiveNotificationOptions | string)
+      | NaiveNotificationOptions
     toastOnSuccess?:
       | boolean
       | string
       | ((
           data: TData,
           query: Query<TQueryFnData, TError, TData, TQueryKey>,
-        ) => NotificationOptions | string)
-      | NotificationOptions
+        ) => NaiveNotificationOptions | string)
+      | NaiveNotificationOptions
   }
 
   // 扩展 MutationMeta 接口
@@ -61,8 +61,8 @@ declare module '@tanstack/vue-query' {
           variables: TVariables,
           context: TContext | undefined,
           mutation: Mutation<TData, TError, TVariables, TContext>,
-        ) => NotificationOptions | string)
-      | NotificationOptions
+        ) => NaiveNotificationOptions | string)
+      | NaiveNotificationOptions
     toastOnSuccess?:
       | boolean
       | string
@@ -71,7 +71,7 @@ declare module '@tanstack/vue-query' {
           variables: TVariables,
           context: TContext | undefined,
           mutation: Mutation<TData, TError, TVariables, TContext>,
-        ) => NotificationOptions | string)
-      | NotificationOptions
+        ) => NaiveNotificationOptions | string)
+      | NaiveNotificationOptions
   }
 }

--- a/src/views/LayoutView.vue
+++ b/src/views/LayoutView.vue
@@ -1,13 +1,14 @@
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, defineAsyncComponent } from 'vue'
 import { useRoute } from 'vue-router'
-import AuthLayoutView from './auth/AuthLayoutView.tsx'
 import UnauthLayoutView from './unauth/UnauthLayoutView'
-import { useAccountStore } from '@/modules/user/application/stores/useAccountStore'
 import { NSpin } from 'naive-ui'
 
+const AuthLayoutView = defineAsyncComponent(() =>
+  import('./auth/AuthLayoutView.tsx').then((module) => module.default),
+)
+
 const route = useRoute()
-const accountStore = useAccountStore()
 
 /**
  * 根据路由 meta.layout 动态选择布局
@@ -31,24 +32,18 @@ const currentLayout = computed(() => {
   const requiresAuth = route.meta.requiresAuth !== false
   return requiresAuth ? AuthLayoutView : UnauthLayoutView
 })
-
-/**
- * 是否显示加载状态
- * 当用户已登录但数据未加载完成时显示
- */
-const isLoading = computed(() => {
-  return accountStore.isAuth && !accountStore.isLoadedData
-})
 </script>
 
 <template>
-  <!-- 全局加载状态 -->
-  <div v-if="isLoading" class="flex items-center justify-center h-screen">
-    <n-spin size="large" />
-  </div>
-
   <!-- 动态布局 -->
-  <component v-else :is="currentLayout">
-    <router-view />
-  </component>
+  <Suspense>
+    <component :is="currentLayout">
+      <router-view />
+    </component>
+    <template #fallback>
+      <div class="flex items-center justify-center h-screen">
+        <n-spin size="large" />
+      </div>
+    </template>
+  </Suspense>
 </template>

--- a/src/views/__tests__/LayoutView.spec.ts
+++ b/src/views/__tests__/LayoutView.spec.ts
@@ -1,23 +1,15 @@
 import { defineComponent, h } from 'vue'
-import { mount } from '@vue/test-utils'
+import { flushPromises, mount } from '@vue/test-utils'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { routeState, accountState } = vi.hoisted(() => ({
+const { routeState } = vi.hoisted(() => ({
   routeState: {
     meta: {} as Record<string, unknown>,
-  },
-  accountState: {
-    isAuth: false,
-    isLoadedData: true,
   },
 }))
 
 vi.mock('vue-router', () => ({
   useRoute: () => routeState,
-}))
-
-vi.mock('@/modules/user/application/stores/useAccountStore', () => ({
-  useAccountStore: () => accountState,
 }))
 
 vi.mock('@/views/auth/AuthLayoutView.tsx', () => ({
@@ -66,19 +58,6 @@ const createWrapper = () =>
 describe('LayoutView', () => {
   beforeEach(() => {
     routeState.meta = {}
-    accountState.isAuth = false
-    accountState.isLoadedData = true
-  })
-
-  it('shows loading spinner when authenticated user data is not loaded', () => {
-    accountState.isAuth = true
-    accountState.isLoadedData = false
-
-    const wrapper = createWrapper()
-
-    expect(wrapper.find('[data-test="n-spin"]').exists()).toBe(true)
-    expect(wrapper.find('[data-test="auth-layout"]').exists()).toBe(false)
-    expect(wrapper.find('[data-test="unauth-layout"]').exists()).toBe(false)
   })
 
   it('uses unauth layout when route meta.layout is unauth', () => {
@@ -92,12 +71,13 @@ describe('LayoutView', () => {
     expect(wrapper.find('[data-test="auth-layout"]').exists()).toBe(false)
   })
 
-  it('uses auth layout when route meta.layout is auth', () => {
+  it('uses auth layout when route meta.layout is auth', async () => {
     routeState.meta = {
       layout: 'auth',
     }
 
     const wrapper = createWrapper()
+    await flushPromises()
 
     expect(wrapper.find('[data-test="auth-layout"]').exists()).toBe(true)
     expect(wrapper.find('[data-test="unauth-layout"]').exists()).toBe(false)
@@ -114,10 +94,11 @@ describe('LayoutView', () => {
     expect(wrapper.find('[data-test="auth-layout"]').exists()).toBe(false)
   })
 
-  it('falls back to auth layout when requiresAuth is missing', () => {
+  it('falls back to auth layout when requiresAuth is missing', async () => {
     routeState.meta = {}
 
     const wrapper = createWrapper()
+    await flushPromises()
 
     expect(wrapper.find('[data-test="auth-layout"]').exists()).toBe(true)
     expect(wrapper.find('[data-test="unauth-layout"]').exists()).toBe(false)


### PR DESCRIPTION
## Summary
- defer heavy bootstrap and enhancement work until after login is established
- simplify auth guard bootstrap path and reduce eager startup work
- reuse eager dashboard placeholders through router-level cleanup

## Scope
- auth guard bootstrap
- plugin initialization and post-login enhancements
- related observability and layout bootstrap wiring

## Test Plan
- `pnpm exec vitest run src/router/guards/__tests__/SetupAuthGuard.spec.ts src/app/plugins/__tests__/usePlugins.spec.ts src/app/plugins/__tests__/useRequestPlugin.spec.ts src/app/observability/components/__tests__/ErrorBoundary.spec.tsx src/router/guards/__tests__/SetupAbilityGuard.spec.ts src/modules/access/presentation/directives/__tests__/can.spec.ts src/modules/user/application/hooks/__tests__/auth-hooks.spec.ts`
- `pnpm type-check`
