### PR TITLE
refactor(access): clean up display-name and legacy role checks

### DIFF
--- a/src/directives/__tests__/permission.spec.ts
+++ b/src/directives/__tests__/permission.spec.ts
@@ -55,15 +55,17 @@ describe('permission directive', () => {
     expect(el.isConnected).toBe(false)
   })
 
-  it('checks role when arg is role and keeps element when authorized', () => {
+  it('does not check role even when arg is role and still relies on permission only', () => {
+    hasPermissionSpy.mockReturnValue(false)
+
     const el = document.createElement('div')
     document.body.appendChild(el)
 
     directive.mounted?.(el, createBinding('admin', 'role'))
 
-    expect(hasRoleSpy).toHaveBeenCalledWith('admin')
-    expect(hasPermissionSpy).not.toHaveBeenCalled()
-    expect(el.isConnected).toBe(true)
+    expect(hasRoleSpy).not.toHaveBeenCalled()
+    expect(hasPermissionSpy).toHaveBeenCalledWith('admin')
+    expect(el.isConnected).toBe(false)
   })
 
   it('requires all permissions when binding value is an array', () => {

--- a/src/directives/permission.ts
+++ b/src/directives/permission.ts
@@ -21,26 +21,18 @@ const permissionDirective: Directive = {
 }
 
 function checkPermission(el: HTMLElement, binding: DirectiveBinding<string | string[]>) {
-  const { value, arg } = binding
+  const { value } = binding
 
   // 如果没有传递任何值，则不进行任何操作
   if (!value) {
     return
   }
 
-  let hasAuth = false
-
-  // 判断是检查角色还是权限
-  // 用法: v-permission:role="'admin'"
-  if (arg === 'role') {
-    hasAuth = accountStore.hasRole(value as string)
-  } else {
-    // 默认检查权限
-    // 用法: v-permission="'article:create'"
-    // 或者 v-permission="['article:create', 'article:publish']" (需要同时拥有)
-    const requiredPermissions = Array.isArray(value) ? value : [value]
-    hasAuth = requiredPermissions.every((perm) => accountStore.hasPermission(perm))
-  }
+  // 统一仅按 permission 校验
+  // 用法: v-permission="'article:create'"
+  // 或者 v-permission="['article:create', 'article:publish']" (需要同时拥有)
+  const requiredPermissions = Array.isArray(value) ? value : [value]
+  const hasAuth = requiredPermissions.every((perm) => accountStore.hasPermission(perm))
 
   // 如果没有权限，则从DOM中移除该元素
   if (!hasAuth) {

--- a/src/modules/access/application/__tests__/ability.spec.ts
+++ b/src/modules/access/application/__tests__/ability.spec.ts
@@ -16,19 +16,19 @@ describe('access ability', () => {
     expect(a.can('manage', 'all')).toBe(false)
   })
 
-  it('defineAbilityFor grants full access for admin role', () => {
+  it('defineAbilityFor does not grant full access by role name and still reads role permissions', () => {
     const ability = defineAbilityFor([], [
       {
         id: 1,
         name: 'admin',
         description: 'admin role',
-        permissions: [],
+        permissions: [{ id: 2, name: 'user:read', description: 'read user' }],
       },
     ])
 
-    expect(ability.can('manage', 'all')).toBe(true)
-    expect(ability.can('delete', 'User')).toBe(true)
-    expect(ability.can('approve', 'Approval')).toBe(true)
+    expect(ability.can('manage', 'all')).toBe(false)
+    expect(ability.can('read', 'User')).toBe(true)
+    expect(ability.can('delete', 'User')).toBe(false)
   })
 
   it('defineAbilityFor parses direct and role permissions including wildcard', () => {

--- a/src/modules/access/application/ability.ts
+++ b/src/modules/access/application/ability.ts
@@ -95,14 +95,7 @@ export function defineAbilityFor(
 ): AppAbility {
   const { can, build } = new AbilityBuilder<AppAbility>(Ability as AbilityClass<AppAbility>)
 
-  // 1. 处理角色权限
-  // 如果用户是管理员，拥有所有权限
-  if (roles.some((role) => role.name === 'admin' || role.name === 'super_admin')) {
-    can('manage', 'all')
-    return build()
-  }
-
-  // 2. 处理细粒度权限
+  // 1. 处理细粒度权限
   permissions.forEach((permission) => {
     const rule = parsePermission(permission.name)
     if (rule) {
@@ -110,7 +103,7 @@ export function defineAbilityFor(
     }
   })
 
-  // 3. 处理角色中的权限
+  // 2. 处理角色中的权限
   roles.forEach((role) => {
     role.permissions?.forEach((permission) => {
       const rule = parsePermission(permission.name)

--- a/src/modules/access/presentation/role/RoleAssign.vue
+++ b/src/modules/access/presentation/role/RoleAssign.vue
@@ -5,6 +5,7 @@ import { NTransfer, NCard, NSpace, NButton, NPopconfirm } from 'naive-ui'
 import { computed, watch } from 'vue'
 import { ref } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { resolveUserDisplayName } from '@/modules/user/application/utils/displayName'
 const { t: $t } = useI18n()
 const props = defineProps<{
   roleId: number
@@ -24,12 +25,14 @@ const assignedUsersHook = useAssignedUsersByRole(props.roleId)
 
 // options
 const options = computed(() => {
-  return userPageQuery.data.value?.records.map((item) => {
-    return {
-      label: `${item.name}#${item.discriminator}`,
-      value: item.id,
-    }
-  })
+  return (
+    userPageQuery.data.value?.records.map((item) => {
+      return {
+        label: resolveUserDisplayName(item),
+        value: item.id,
+      }
+    }) ?? []
+  )
 })
 // Build a transfer showing the users, with the ability to assign a role by checking a selection.
 const selectedUserIds = ref<number[]>([])

--- a/src/modules/access/presentation/role/__tests__/RoleAssign.spec.ts
+++ b/src/modules/access/presentation/role/__tests__/RoleAssign.spec.ts
@@ -22,8 +22,8 @@ vi.mock('@/modules/user/application/hooks/useUserPage', () => ({
     data: {
       value: {
         records: [
-          { id: 1, name: 'Alice', discriminator: 'A' },
-          { id: 2, name: 'Bob', discriminator: 'B' },
+          { id: 1, name: 'Alice', discriminator: 1 },
+          { id: 2, name: 'Bob', discriminator: 2 },
         ],
       },
     },
@@ -99,13 +99,16 @@ vi.mock('naive-ui', () => ({
     },
     emits: ['update:value'],
     setup(props, { emit }) {
-      return () =>
-        h('button', {
+      return () => {
+        const labels = (props.options || []).map((item) => (item as { label: string }).label)
+        return h('button', {
           'data-test': 'n-transfer',
           'data-value': JSON.stringify(props.value ?? []),
           'data-options-len': String((props.options || []).length),
+          'data-options-labels': JSON.stringify(labels),
           onClick: () => emit('update:value', [1]),
         })
+      }
     },
   }),
 }))
@@ -127,6 +130,7 @@ describe('RoleAssign', () => {
 
     const transfer = wrapper.get('[data-test="n-transfer"]')
     expect(transfer.attributes('data-options-len')).toBe('2')
+    expect(transfer.attributes('data-options-labels')).toBe('["Alice#1","Bob#2"]')
     expect(transfer.attributes('data-value')).toBe('[]')
 
     if (!assignedUsersRefHolder.value) {

--- a/src/modules/approval/application/__tests__/utils.spec.ts
+++ b/src/modules/approval/application/__tests__/utils.spec.ts
@@ -192,8 +192,10 @@ describe('approval utils', () => {
 
   it('showIncompletedUserName handles missing/numeric/normal names', () => {
     expect(showIncompletedUserName(undefined)).toBe('common.label.none')
-    expect(showIncompletedUserName(' 123 ')).toBe('domain.approval.label.incompleteUser# 123 ')
+    expect(showIncompletedUserName(' 123 ')).toBe('domain.approval.label.incompleteUser#123')
+    expect(showIncompletedUserName('   ')).toBe('common.label.none')
     expect(showIncompletedUserName('王五')).toBe('王五')
+    expect(showIncompletedUserName('王五#0')).toBe('王五')
   })
 
   it('status helper functions return expected visibility and accessibility', () => {

--- a/src/modules/approval/application/utils.ts
+++ b/src/modules/approval/application/utils.ts
@@ -5,6 +5,7 @@ import type {
   ApprovalTaskStatus,
 } from '@/modules/approval/application/models'
 import type { SignInResponseComplete } from '@/modules/user/application/models'
+import { resolveUserDisplayText } from '@/modules/user/application/utils/displayName'
 
 export type ClaimTaskError = {
   canClaim: boolean
@@ -156,11 +157,10 @@ export function checkTasksClaimable(
  * @returns string 完整用户名
  */
 export function showIncompletedUserName(name: string | null | undefined): string {
-  if (typeof name !== 'string') return $t('common.label.none')
-  if (/^-?\d+(\.\d+)?$/.test(name.trim())) {
-    return `${$t('domain.approval.label.incompleteUser')}#${name}`
-  }
-  return name
+  return resolveUserDisplayText(name, {
+    emptyFallback: $t('common.label.none'),
+    numericNamePrefix: $t('domain.approval.label.incompleteUser'),
+  })
 }
 
 export function isShowApprovalBtn(status: ApprovalTaskStatus | undefined) {

--- a/src/modules/approval/application/utils.ts
+++ b/src/modules/approval/application/utils.ts
@@ -20,8 +20,14 @@ export type ClaimTaskError = {
  */
 export function canClaimTask(
   instance: ApprovalInstance<Record<string, unknown>>,
-  currentUser: SignInResponseComplete,
+  currentUser?: SignInResponseComplete | null,
 ): ClaimTaskError {
+  if (!currentUser?.user) {
+    return {
+      canClaim: false,
+    }
+  }
+
   // 1. 检查任务是否存在
   if (!instance.taskId) {
     return {
@@ -139,7 +145,7 @@ export function canApproveTask(
  */
 export function checkTasksClaimable(
   instances: ApprovalInstance<Record<string, unknown>>[],
-  currentUser: SignInResponseComplete,
+  currentUser?: SignInResponseComplete | null,
 ) {
   const result = new Map()
 

--- a/src/modules/approval/presentation/approval/ApprovalInstancePage.vue
+++ b/src/modules/approval/presentation/approval/ApprovalInstancePage.vue
@@ -13,10 +13,10 @@ import {
   canClaimTask,
   isApprovalFinish,
   isApproveBtnVisible,
-  showIncompletedUserName,
 } from '@/modules/approval/application/utils'
 import { useAccountStore } from '@/modules/user/application/stores/useAccountStore'
 import type { SignInResponseComplete } from '@/modules/user/application/models'
+import { resolveUserDisplayText } from '@/modules/user/application/utils/displayName'
 import { formatted } from '@/modules/shared/presentation/time'
 import { useRouter } from 'vue-router'
 import StatusTag from './StatusTag'
@@ -52,6 +52,11 @@ const claimMutation = useClaimTask()
 const { onSearch: handleSearchWithRefetch, onReset: handleResetWithRefetch } = bindRefetchHandlers(
   () => instanceQuery.refetch(),
 )
+const formatApprovalUserName = (name: string | null | undefined) =>
+  resolveUserDisplayText(name, {
+    emptyFallback: $t('common.label.none'),
+    numericNamePrefix: $t('domain.approval.label.incompleteUser'),
+  })
 
 const handleApprove = (row: Row) => {
   router.push({
@@ -106,7 +111,7 @@ const columns = computed<DataTableColumns<Row>>(() => [
             h(MobilePrimarySecondaryText, {
               primary: row.processName,
               secondary: [
-                `${row.nodeName} · ${showIncompletedUserName(row.applicantName)}`,
+                `${row.nodeName} · ${formatApprovalUserName(row.applicantName)}`,
                 formatted(row.createdTime).standard,
               ],
             }),
@@ -147,12 +152,12 @@ const columns = computed<DataTableColumns<Row>>(() => [
         {
           title: $t('domain.approval.field.approver'),
           key: 'assigneeName',
-          render: (row: Row) => showIncompletedUserName(row.assigneeName),
+          render: (row: Row) => formatApprovalUserName(row.assigneeName),
         },
         {
           title: $t('domain.approval.field.applicant'),
           key: 'applicantName',
-          render: (row: Row) => showIncompletedUserName(row.applicantName),
+          render: (row: Row) => formatApprovalUserName(row.applicantName),
         },
         {
           title: $t('common.time.created'),

--- a/src/modules/approval/presentation/approval/TemplateNode.tsx
+++ b/src/modules/approval/presentation/approval/TemplateNode.tsx
@@ -1,7 +1,7 @@
 import { defineComponent, type PropType, computed, h } from 'vue'
 import { $t } from '@/_utils/i18n'
 import type { ApprovalInstance, ApprovalTaskStatus } from '@/modules/approval/application/models'
-import { showIncompletedUserName } from '@/modules/approval/application/utils'
+import { resolveUserDisplayText } from '@/modules/user/application/utils/displayName'
 import StatusTag from './StatusTag'
 import type { ApprovalInstanceStatus } from '@/modules/approval/domain/enums'
 
@@ -14,6 +14,12 @@ export default defineComponent({
     },
   },
   setup(props) {
+    const formatApprovalUserName = (name: string | null | undefined) =>
+      resolveUserDisplayText(name, {
+        emptyFallback: $t('common.label.none'),
+        numericNamePrefix: $t('domain.approval.label.incompleteUser'),
+      })
+
     const statusText = computed(() => {
       return ['rejected', 'canceled', 'approved'].includes(props.data.status)
         ? h(
@@ -42,9 +48,9 @@ export default defineComponent({
             </tr>
             <tr>
               <td class="label">{$t('domain.approval.field.applicant')}</td>
-              <td class="value">{showIncompletedUserName(props.data.applicantName)}</td>
+              <td class="value">{formatApprovalUserName(props.data.applicantName)}</td>
               <td class="label">{$t('domain.approval.field.approver')}</td>
-              <td class="value">{showIncompletedUserName(props.data.assigneeName)}</td>
+              <td class="value">{formatApprovalUserName(props.data.assigneeName)}</td>
             </tr>
             <tr>
               <td class="label">{$t('common.label.status')}</td>

--- a/src/modules/approval/presentation/approval/TemplateRecord.tsx
+++ b/src/modules/approval/presentation/approval/TemplateRecord.tsx
@@ -3,7 +3,7 @@ import { $t } from '@/_utils/i18n'
 import type { ApprovalInstance } from '@/modules/approval/application/models'
 import { useApprovalHistoryQuery } from '@/modules/approval/application/hooks/useApprovalService'
 import { formatted } from '@/modules/shared/presentation/time'
-import { showIncompletedUserName } from '@/modules/approval/application/utils'
+import { resolveUserDisplayText } from '@/modules/user/application/utils/displayName'
 import { match } from 'ts-pattern'
 
 type I18nKey = Parameters<typeof $t>[0]
@@ -28,6 +28,12 @@ export default defineComponent({
     },
   },
   setup(props) {
+    const formatApprovalUserName = (name: string | null | undefined) =>
+      resolveUserDisplayText(name, {
+        emptyFallback: $t('common.label.none'),
+        numericNamePrefix: $t('domain.approval.label.incompleteUser'),
+      })
+
     const { data: historyData } = useApprovalHistoryQuery(computed(() => props.data.id))
 
     const list = computed(() => {
@@ -60,7 +66,7 @@ export default defineComponent({
               list.value.map((row) => (
                 <tr key={row.id}>
                   <td>{row.nodeName}</td>
-                  <td>{showIncompletedUserName(row.operator)}</td>
+                  <td>{formatApprovalUserName(row.operator)}</td>
                   <td>
                     {
                       // Map actions to new common or domain keys

--- a/src/modules/approval/presentation/approval/__tests__/TemplateNode.spec.tsx
+++ b/src/modules/approval/presentation/approval/__tests__/TemplateNode.spec.tsx
@@ -6,8 +6,8 @@ vi.mock('@/_utils/i18n', () => ({
   $t: vi.fn((key: string) => key),
 }))
 
-vi.mock('@/modules/approval/application/utils', () => ({
-  showIncompletedUserName: vi.fn((name: string) => `masked:${name}`),
+vi.mock('@/modules/user/application/utils/displayName', () => ({
+  resolveUserDisplayText: vi.fn((name: string) => `masked:${name}`),
 }))
 
 vi.mock('@/modules/approval/presentation/approval/StatusTag', () => ({

--- a/src/modules/approval/presentation/approval/__tests__/TemplateRecord.spec.tsx
+++ b/src/modules/approval/presentation/approval/__tests__/TemplateRecord.spec.tsx
@@ -9,8 +9,8 @@ vi.mock('@/_utils/i18n', () => ({
   $t: vi.fn((key: string) => key),
 }))
 
-vi.mock('@/modules/approval/application/utils', () => ({
-  showIncompletedUserName: vi.fn((name: string) => `masked:${name}`),
+vi.mock('@/modules/user/application/utils/displayName', () => ({
+  resolveUserDisplayText: vi.fn((name: string) => `masked:${name}`),
 }))
 
 vi.mock('@/modules/shared/presentation/time', () => ({

--- a/src/modules/approval/presentation/approval/diff-check/ApprovalBaseInfoDiffCheck.tsx
+++ b/src/modules/approval/presentation/approval/diff-check/ApprovalBaseInfoDiffCheck.tsx
@@ -1,6 +1,6 @@
 import { $t } from '@/_utils/i18n'
 import type { ApprovalInstance } from '@/modules/approval/application/models'
-import { showIncompletedUserName } from '@/modules/approval/application/utils'
+import { resolveUserDisplayText } from '@/modules/user/application/utils/displayName'
 import { defineComponent, type PropType, computed } from 'vue'
 
 type I18nKey = Parameters<typeof $t>[0]
@@ -28,6 +28,12 @@ export default defineComponent({
     },
   },
   setup(props) {
+    const formatApprovalUserName = (name: string | null | undefined) =>
+      resolveUserDisplayText(name, {
+        emptyFallback: $t('common.label.none'),
+        numericNamePrefix: $t('domain.approval.label.incompleteUser'),
+      })
+
     const statusText = computed(() => {
       const finished = ['rejected', 'canceled', 'approved'].includes(props.data.status)
       return finished ? toStatusText(props.data.status) : toStatusText(props.data.taskStatus)
@@ -44,9 +50,9 @@ export default defineComponent({
           </tr>
           <tr>
             <td class="field-label">{$t('domain.approval.field.applicant')}</td>
-            <td>{showIncompletedUserName(props.data.applicantName)}</td>
+            <td>{formatApprovalUserName(props.data.applicantName)}</td>
             <td class="field-label">{$t('domain.approval.field.approver')}</td>
-            <td>{showIncompletedUserName(props.data.assigneeName)}</td>
+            <td>{formatApprovalUserName(props.data.assigneeName)}</td>
           </tr>
           <tr>
             <td class="field-label">{$t('common.label.status')}</td>

--- a/src/modules/approval/presentation/approval/diff-check/ApprovalHistoryDiffCheck.tsx
+++ b/src/modules/approval/presentation/approval/diff-check/ApprovalHistoryDiffCheck.tsx
@@ -1,6 +1,6 @@
 import { $t } from '@/_utils/i18n'
 import type { ApprovalHistory } from '@/modules/approval/application/models'
-import { showIncompletedUserName } from '@/modules/approval/application/utils'
+import { resolveUserDisplayText } from '@/modules/user/application/utils/displayName'
 import { formatted } from '@/modules/shared/presentation/time'
 import { match } from 'ts-pattern'
 import { defineComponent, type PropType } from 'vue'
@@ -27,6 +27,12 @@ export default defineComponent({
     },
   },
   setup(props) {
+    const formatApprovalUserName = (name: string | null | undefined) =>
+      resolveUserDisplayText(name, {
+        emptyFallback: $t('common.label.none'),
+        numericNamePrefix: $t('domain.approval.label.incompleteUser'),
+      })
+
     return () => (
       <table class="form-table">
         <thead>
@@ -43,7 +49,7 @@ export default defineComponent({
             props.list.map((row) => (
               <tr key={row.id}>
                 <td>{row.nodeName}</td>
-                <td>{showIncompletedUserName(row.operator)}</td>
+                <td>{formatApprovalUserName(row.operator)}</td>
                 <td>{$t(getActionLabelKey(row.action))}</td>
                 <td>{formatted(row.createdTime).standard}</td>
                 <td>{row.comment || '-'}</td>

--- a/src/modules/approval/presentation/approval/diff-check/ApprovalPrintDiffCheck.tsx
+++ b/src/modules/approval/presentation/approval/diff-check/ApprovalPrintDiffCheck.tsx
@@ -1,6 +1,6 @@
 import { $t } from '@/_utils/i18n'
 import type { ApprovalHistory, ApprovalInstance } from '@/modules/approval/application/models'
-import { showIncompletedUserName } from '@/modules/approval/application/utils'
+import { resolveUserDisplayText } from '@/modules/user/application/utils/displayName'
 import { formatted } from '@/modules/shared/presentation/time'
 import { NQrCode } from 'naive-ui'
 import { match } from 'ts-pattern'
@@ -47,6 +47,12 @@ export default defineComponent({
     },
   },
   setup(props) {
+    const formatApprovalUserName = (name: string | null | undefined) =>
+      resolveUserDisplayText(name, {
+        emptyFallback: $t('common.label.none'),
+        numericNamePrefix: $t('domain.approval.label.incompleteUser'),
+      })
+
     const now = new Date().toLocaleString('zh-CN')
 
     const statusText = computed(() => {
@@ -109,9 +115,9 @@ export default defineComponent({
             </tr>
             <tr>
               <td style={{ fontWeight: 'bold' }}>{$t('domain.approval.field.applicant')}</td>
-              <td>{showIncompletedUserName(props.data.applicantName)}</td>
+              <td>{formatApprovalUserName(props.data.applicantName)}</td>
               <td style={{ fontWeight: 'bold' }}>{$t('domain.approval.field.approver')}</td>
-              <td>{showIncompletedUserName(props.data.assigneeName)}</td>
+              <td>{formatApprovalUserName(props.data.assigneeName)}</td>
             </tr>
             <tr>
               <td style={{ fontWeight: 'bold' }}>{$t('common.label.status')}</td>
@@ -143,7 +149,7 @@ export default defineComponent({
               props.historyList.map((row) => (
                 <tr key={row.id}>
                   <td>{row.nodeName}</td>
-                  <td>{showIncompletedUserName(row.operator)}</td>
+                  <td>{formatApprovalUserName(row.operator)}</td>
                   <td>{$t(toActionLabelKey(row.action))}</td>
                   <td>{formatted(row.createdTime).standard}</td>
                   <td>{row.comment || '-'}</td>

--- a/src/modules/approval/presentation/approval/diff-check/__tests__/ApprovalBaseInfoDiffCheck.spec.tsx
+++ b/src/modules/approval/presentation/approval/diff-check/__tests__/ApprovalBaseInfoDiffCheck.spec.tsx
@@ -5,8 +5,8 @@ vi.mock('@/_utils/i18n', () => ({
   $t: vi.fn((key: string) => key),
 }))
 
-vi.mock('@/modules/approval/application/utils', () => ({
-  showIncompletedUserName: vi.fn((name: string) => `masked:${name}`),
+vi.mock('@/modules/user/application/utils/displayName', () => ({
+  resolveUserDisplayText: vi.fn((name: string) => `masked:${name}`),
 }))
 
 import ApprovalBaseInfoDiffCheck from '@/modules/approval/presentation/approval/diff-check/ApprovalBaseInfoDiffCheck'

--- a/src/modules/approval/presentation/approval/diff-check/__tests__/ApprovalHistoryDiffCheck.spec.tsx
+++ b/src/modules/approval/presentation/approval/diff-check/__tests__/ApprovalHistoryDiffCheck.spec.tsx
@@ -5,8 +5,8 @@ vi.mock('@/_utils/i18n', () => ({
   $t: vi.fn((key: string) => key),
 }))
 
-vi.mock('@/modules/approval/application/utils', () => ({
-  showIncompletedUserName: vi.fn((name: string) => `masked:${name}`),
+vi.mock('@/modules/user/application/utils/displayName', () => ({
+  resolveUserDisplayText: vi.fn((name: string) => `masked:${name}`),
 }))
 
 vi.mock('@/modules/shared/presentation/time', () => ({

--- a/src/modules/approval/presentation/approval/diff-check/__tests__/ApprovalPrintDiffCheck.spec.tsx
+++ b/src/modules/approval/presentation/approval/diff-check/__tests__/ApprovalPrintDiffCheck.spec.tsx
@@ -6,8 +6,8 @@ vi.mock('@/_utils/i18n', () => ({
   $t: vi.fn((key: string) => key),
 }))
 
-vi.mock('@/modules/approval/application/utils', () => ({
-  showIncompletedUserName: vi.fn((name: string) => `masked:${name}`),
+vi.mock('@/modules/user/application/utils/displayName', () => ({
+  resolveUserDisplayText: vi.fn((name: string) => `masked:${name}`),
 }))
 
 vi.mock('@/modules/shared/presentation/time', () => ({

--- a/src/modules/service-agreement/presentation/sign/ServiceAgreementPage.tsx
+++ b/src/modules/service-agreement/presentation/sign/ServiceAgreementPage.tsx
@@ -64,7 +64,7 @@ export default defineComponent({
           mobileColumns.push({
             title: $t('common.action.operate'),
             key: 'operate',
-            render: (row) => slots.actions!(row),
+            render: (row: ServiceAgreementPageItem) => slots.actions!(row),
           })
         }
 
@@ -104,7 +104,7 @@ export default defineComponent({
           title: $t('common.action.operate'),
           key: 'operate',
           fixed: 'right',
-          render: (row) => slots.actions!(row),
+          render: (row: ServiceAgreementPageItem) => slots.actions!(row),
         })
       }
       return baseColumn

--- a/src/modules/user/application/__tests__/displayName.spec.ts
+++ b/src/modules/user/application/__tests__/displayName.spec.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+import {
+  resolveUserDisplayName,
+  resolveUserDisplayText,
+} from '@/modules/user/application/utils/displayName'
+
+describe('resolveUserDisplayName', () => {
+  it('appends positive discriminator', () => {
+    expect(resolveUserDisplayName({ name: 'alice', discriminator: 7 })).toBe('alice#7')
+  })
+
+  it('supports positive numeric-string discriminator', () => {
+    expect(resolveUserDisplayName({ name: 'alice', discriminator: '007' })).toBe('alice#007')
+    expect(resolveUserDisplayName({ name: 'alice', discriminator: ' 42 ' })).toBe('alice#42')
+  })
+
+  it('returns name when discriminator is missing or non-positive', () => {
+    expect(resolveUserDisplayName({ name: 'alice', discriminator: 0 })).toBe('alice')
+    expect(resolveUserDisplayName({ name: 'alice', discriminator: -1 })).toBe('alice')
+    expect(resolveUserDisplayName({ name: 'alice', discriminator: 'A' })).toBe('alice')
+    expect(resolveUserDisplayName({ name: 'alice', discriminator: '0' })).toBe('alice')
+    expect(resolveUserDisplayName({ name: 'alice', discriminator: null })).toBe('alice')
+    expect(resolveUserDisplayName({ name: 'alice' })).toBe('alice')
+  })
+
+  it('returns empty string when name is missing', () => {
+    expect(resolveUserDisplayName({ name: '', discriminator: 7 })).toBe('')
+    expect(resolveUserDisplayName({ name: null, discriminator: 7 })).toBe('')
+  })
+
+  it('normalizes trailing discriminator in name text', () => {
+    expect(resolveUserDisplayName({ name: 'alice#7' })).toBe('alice#7')
+    expect(resolveUserDisplayName({ name: 'alice#0' })).toBe('alice')
+    expect(resolveUserDisplayName({ name: 'alice#-1' })).toBe('alice')
+  })
+
+  it('uses explicit discriminator over trailing discriminator in name text', () => {
+    expect(resolveUserDisplayName({ name: 'alice#7', discriminator: 9 })).toBe('alice#9')
+    expect(resolveUserDisplayName({ name: 'alice#7', discriminator: 0 })).toBe('alice')
+  })
+})
+
+describe('resolveUserDisplayText', () => {
+  it('returns fallback when name is empty', () => {
+    expect(resolveUserDisplayText(undefined, { emptyFallback: '-' })).toBe('-')
+  })
+
+  it('supports numeric name prefix for semantic labels', () => {
+    expect(
+      resolveUserDisplayText(' 123 ', {
+        numericNamePrefix: 'domain.approval.label.incompleteUser',
+      }),
+    ).toBe('domain.approval.label.incompleteUser#123')
+  })
+
+  it('returns normalized text for normal names', () => {
+    expect(resolveUserDisplayText(' Alice ')).toBe('Alice')
+    expect(resolveUserDisplayText('  Alice ', { trimName: false })).toBe('  Alice ')
+  })
+
+  it('drops invalid trailing #0 suffix from name text', () => {
+    expect(resolveUserDisplayText('张三#0')).toBe('张三')
+  })
+})

--- a/src/modules/user/application/utils/displayName.ts
+++ b/src/modules/user/application/utils/displayName.ts
@@ -1,0 +1,94 @@
+export interface UserDisplayNameInput {
+  name?: string | null
+  discriminator?: number | string | null
+}
+
+export interface UserDisplayTextOptions {
+  emptyFallback?: string
+  numericNamePrefix?: string
+  trimName?: boolean
+}
+
+const parseTrailingDiscriminator = (
+  rawName: string,
+): { baseName: string; trailingDiscriminator: string | null } => {
+  const matched = rawName.match(/^(.*?)(?:\s*#\s*(-?\d+))$/)
+  if (!matched) {
+    return { baseName: rawName, trailingDiscriminator: null }
+  }
+
+  const baseName = matched[1] ?? ''
+  const trailingDiscriminator = matched[2] ?? null
+  return {
+    baseName,
+    trailingDiscriminator,
+  }
+}
+
+const normalizeDiscriminator = (
+  discriminator: number | string | null | undefined,
+): string | null => {
+  if (typeof discriminator === 'number') {
+    if (Number.isFinite(discriminator) && discriminator > 0) {
+      return String(discriminator)
+    }
+    return null
+  }
+
+  if (typeof discriminator === 'string') {
+    const normalized = discriminator.trim()
+    if (/^\d+$/.test(normalized) && Number(normalized) > 0) {
+      return normalized
+    }
+  }
+
+  return null
+}
+
+export function resolveUserDisplayName(input: UserDisplayNameInput): string {
+  const rawName = typeof input.name === 'string' ? input.name : ''
+  if (!rawName) return ''
+
+  const { baseName, trailingDiscriminator } = parseTrailingDiscriminator(rawName)
+  const explicitDiscriminatorProvided = input.discriminator !== undefined && input.discriminator !== null
+  const explicitDiscriminator = normalizeDiscriminator(input.discriminator)
+  const trailingNormalized = normalizeDiscriminator(trailingDiscriminator)
+
+  if (explicitDiscriminatorProvided) {
+    if (explicitDiscriminator) {
+      return `${baseName}#${explicitDiscriminator}`
+    }
+    return baseName
+  }
+
+  if (trailingNormalized) {
+    return `${baseName}#${trailingNormalized}`
+  }
+
+  return baseName
+}
+
+export function resolveUserDisplayText(
+  name: string | null | undefined,
+  options: UserDisplayTextOptions = {},
+): string {
+  const trimName = options.trimName ?? true
+  const normalizedName = typeof name === 'string' ? (trimName ? name.trim() : name) : ''
+
+  if (!normalizedName) {
+    return options.emptyFallback ?? ''
+  }
+
+  if (
+    options.numericNamePrefix &&
+    /^\d+$/.test(normalizedName) &&
+    Number(normalizedName) > 0
+  ) {
+    return resolveUserDisplayName({
+      name: options.numericNamePrefix,
+      discriminator: normalizedName,
+    })
+  }
+
+  return resolveUserDisplayName({ name: normalizedName })
+}

--- a/src/modules/user/presentation/manage/UserListPage.tsx
+++ b/src/modules/user/presentation/manage/UserListPage.tsx
@@ -13,6 +13,7 @@ import MobilePrimarySecondaryText from '@/modules/shared/presentation/widget/Mob
 import { userListAdvancedQueryFields } from './userListAdvancedQueryFields'
 import { RegisterTypeOption } from '@/modules/user/application/constants'
 import { resolvePlatformLabelKey } from '@/modules/user/application/utils/platform'
+import { resolveUserDisplayName } from '@/modules/user/application/utils/displayName'
 import { usePermission } from '@/modules/access/application/hooks/useCan'
 import { useIsMobile } from '@/app/presentation/hooks/useIsMobile'
 
@@ -54,8 +55,7 @@ export default defineComponent({
     const registerTypeLabel = (type: number) =>
       RegisterTypeOption.find((option) => option.value === type)?.label ?? '-'
 
-    const displayName = (row: UserPageItem) =>
-      row.discriminator > 0 ? `${row.name}#${row.discriminator}` : row.name
+    const displayName = (row: UserPageItem) => resolveUserDisplayName(row)
 
     const activationLabel = (enabled: boolean) =>
       enabled ? $t('domain.user.status.active') : $t('domain.user.status.inactive')

--- a/src/modules/work-order/presentation/WorkOrderDetailPage.vue
+++ b/src/modules/work-order/presentation/WorkOrderDetailPage.vue
@@ -39,6 +39,7 @@ import type { WorkOrderReplyVO } from '../domain/types'
 import WorkOrderStatusBadge from './WorkOrderStatusBadge'
 import WorkOrderScoreSection from './WorkOrderScoreSection.vue'
 import { formatted } from '@/modules/shared/presentation/time'
+import { resolveUserDisplayName } from '@/modules/user/application/utils/displayName'
 
 const route = useRoute()
 const { t: $t } = useI18n()
@@ -56,6 +57,9 @@ const workOrderId = computed(() => {
 
 const isHandler = computed(() => accountStore.hasRole('work_order_handler'))
 const currentUserId = computed(() => accountStore.account?.user?.id ?? accountStore.user.id)
+const currentUserDisplayName = computed(() =>
+  resolveUserDisplayName({ name: accountStore.user.name }),
+)
 
 // Queries - use handler or user endpoints based on role
 const userDetailQuery = useWorkOrderDetail(workOrderId, {
@@ -162,26 +166,29 @@ const canScore = computed(() => isOwner.value && detail.value?.status === WorkOr
 
 const initiatorName = computed(() => {
   if (!detail.value) return '-'
-  if (detail.value.userName) return detail.value.userName
-  if (accountStore.isOwner(detail.value.userId) && accountStore.user.name) {
-    return accountStore.user.name
+  const detailUserDisplayName = resolveUserDisplayName({ name: detail.value.userName })
+  if (detailUserDisplayName) return detailUserDisplayName
+  if (accountStore.isOwner(detail.value.userId) && currentUserDisplayName.value) {
+    return currentUserDisplayName.value
   }
   return `#${detail.value.userId}`
 })
 
 const claimerName = computed(() => {
   if (!detail.value || detail.value.currentHandlerId == null) return null
-  if (detail.value.currentHandlerName) return detail.value.currentHandlerName
-  if (detail.value.currentHandlerId === currentUserId.value && accountStore.user.name) {
-    return accountStore.user.name
+  const handlerDisplayName = resolveUserDisplayName({ name: detail.value.currentHandlerName })
+  if (handlerDisplayName) return handlerDisplayName
+  if (detail.value.currentHandlerId === currentUserId.value && currentUserDisplayName.value) {
+    return currentUserDisplayName.value
   }
   return `#${detail.value.currentHandlerId}`
 })
 
 const replyAuthorName = (reply: WorkOrderReplyVO) => {
-  if (reply.userName) return reply.userName
-  if (reply.userId === currentUserId.value && accountStore.user.name) {
-    return accountStore.user.name
+  const replyUserDisplayName = resolveUserDisplayName({ name: reply.userName })
+  if (replyUserDisplayName) return replyUserDisplayName
+  if (reply.userId === currentUserId.value && currentUserDisplayName.value) {
+    return currentUserDisplayName.value
   }
   return `#${reply.userId}`
 }

--- a/src/router/types.ts
+++ b/src/router/types.ts
@@ -23,8 +23,6 @@ export interface AppRouteMeta {
   requiresAuth?: boolean
   /** 需要的权限列表（旧方式，兼容保留） */
   permissions?: string[]
-  /** 需要的角色列表（旧方式，兼容保留） */
-  roles?: string[]
   /** CASL 权限规则（推荐使用） */
   ability?: AbilityRule | AbilityRule[]
 }

--- a/src/types/vendor/vue-router.d.ts
+++ b/src/types/vendor/vue-router.d.ts
@@ -2,8 +2,6 @@ import 'vue-router'
 
 declare module 'vue-router' {
   interface RouteMeta {
-    // 如果设置，则会根据用户信息判断roles
-    roles?: string[]
     // 如果设置，则会根据用户信息判断permission
     permissions?: string[]
     // 用于面包屑以及菜单展示路由名称

--- a/src/views/auth/AuthLayoutView.tsx
+++ b/src/views/auth/AuthLayoutView.tsx
@@ -29,6 +29,7 @@ import { language, setLanguage, type AppLocale } from '@/_utils/i18n'
 import type { AppRouteRecord } from '@/router/types'
 import { useAccountStore } from '@/modules/user/application/stores/useAccountStore'
 import { resolvePlatformLabelKey } from '@/modules/user/application/utils/platform'
+import { resolveUserDisplayName } from '@/modules/user/application/utils/displayName'
 import ErrorBoundary from '@/app/observability/components/ErrorBoundary'
 import logoSvgUrl from '@/assets/logo.svg?url'
 
@@ -147,6 +148,10 @@ export default defineComponent({
       t(resolvePlatformLabelKey(accountStore.user.platform)),
     )
 
+    const sidebarUserDisplayName = computed(() =>
+      resolveUserDisplayName({ name: accountStore.user.name }),
+    )
+    const sidebarUserInitial = computed(() => sidebarUserDisplayName.value.slice(0, 1) || 'U')
     const shouldShowSidebarPlatform = computed(() => accountStore.user.platform !== 'NATIVE')
     const mobileTabsDrawerWidth = 'min(calc(var(--sider-width) + var(--spacing-80)), 88vw)'
     const activeTabTitle = computed(() => {
@@ -350,7 +355,7 @@ export default defineComponent({
                       height: sidebarAvatarSize,
                     }}
                   >
-                    {(accountStore.user.name || 'U').slice(0, 1)}
+                    {sidebarUserInitial.value}
                   </div>
                 </div>
               </>
@@ -368,11 +373,11 @@ export default defineComponent({
                       height: sidebarAvatarSize,
                     }}
                   >
-                    {(accountStore.user.name || 'U').slice(0, 1)}
+                    {sidebarUserInitial.value}
                   </div>
                   <div class="flex-1 min-w-0">
                     <div class="text-sm font-medium text-[var(--color-text-main)] truncate">
-                      {accountStore.user.name || t('layout.menu.profile')}
+                      {sidebarUserDisplayName.value || t('layout.menu.profile')}
                     </div>
                     <div class="text-xs text-[var(--color-text-light)] truncate">
                       {`${t('layout.profile.field.phone')}: ${accountStore.user.phone || '-'}`}

--- a/src/views/auth/UserProfileView.vue
+++ b/src/views/auth/UserProfileView.vue
@@ -21,6 +21,7 @@ import { useAccountStore } from '@/modules/user/application/stores/useAccountSto
 import { useLoadUserInfo } from '@/modules/user/application/hooks/useLoadUserInfo'
 import { message } from '@/_utils/discrete_naive_api'
 import { resolvePlatformLabelKey } from '@/modules/user/application/utils/platform'
+import { resolveUserDisplayName } from '@/modules/user/application/utils/displayName'
 import { useServiceAgreementPage } from '@/modules/service-agreement/application/hooks/useSignService'
 import { ServiceAgreementStatusEnum } from '@/modules/service-agreement/application/constants'
 import type { ServiceAgreementPageQuery } from '@/modules/service-agreement/application/models'
@@ -63,14 +64,14 @@ const signPage = useServiceAgreementPage(signPageRequest)
 const currentUser = computed(() => loadUserInfo.data.value?.user ?? account.user)
 const currentProfile = computed(() => loadUserInfo.data.value?.profile ?? account.profile)
 
-const profileName = computed(() => currentUser.value.name || '-')
+const resolvedProfileName = computed(() => resolveUserDisplayName({ name: currentUser.value.name }))
+const profileName = computed(() => resolvedProfileName.value || '-')
 const phoneNumber = computed(() => currentUser.value.phone || '-')
 const platformLabel = computed(() => $t(resolvePlatformLabelKey(currentUser.value.platform)))
 const shouldShowPlatform = computed(() => currentUser.value.platform !== 'NATIVE')
 const avatarText = computed(() => {
-  const displayName = profileName.value
-  if (!displayName || displayName === '-') return 'U'
-  return displayName.slice(0, 1)
+  if (!resolvedProfileName.value) return 'U'
+  return resolvedProfileName.value.slice(0, 1)
 })
 const actionIconSize = 'var(--spacing-16)'
 const avatarUploadActionSize = 'var(--spacing-32)'

--- a/src/views/auth/UserSettingsView.vue
+++ b/src/views/auth/UserSettingsView.vue
@@ -140,8 +140,10 @@ const deviceColumns = computed<DataTableColumns<UserDeviceSession>>(() => {
       {
         title: $t('layout.profile.security.devices.field.deviceId'),
         key: 'deviceId',
-        render: (row) =>
-          h('div', { class: 'min-w-0' }, [
+        render: (row) => {
+          const lastActiveAt = formatted(row.lastActiveAt).standard || unknown
+
+          return h('div', { class: 'settings-device-session-cell min-w-0' }, [
             h(
               'div',
               { class: 'text-sm font-medium text-[var(--color-text-main)] truncate' },
@@ -157,12 +159,13 @@ const deviceColumns = computed<DataTableColumns<UserDeviceSession>>(() => {
               { class: 'text-xs text-[var(--color-text-light)] truncate mt-1' },
               row.userAgent || unknown,
             ),
-          ]),
-      },
-      {
-        title: $t('layout.profile.security.devices.field.lastActiveAt'),
-        key: 'lastActiveAt',
-        render: (row) => formatted(row.lastActiveAt).standard,
+            h(
+              'div',
+              { class: 'text-xs text-[var(--color-text-light)] truncate mt-1' },
+              `${$t('layout.profile.security.devices.field.lastActiveAt')}: ${lastActiveAt}`,
+            ),
+          ])
+        },
       },
       {
         title: $t('layout.profile.security.devices.field.currentDevice'),
@@ -532,6 +535,10 @@ const handleRevokeSelectedDevices = async () => {
 </template>
 
 <style scoped>
+.settings-device-session-cell {
+  min-width: 16rem;
+}
+
 .settings-password-form-shell {
   width: 100%;
   max-inline-size: 35rem;


### PR DESCRIPTION
## Summary
- centralize user display-name formatting into a reusable utility
- remove legacy role-name shortcuts from access and permission handling
- tighten approval claim checks when current user context is missing
- improve device session row readability in profile/settings UI

## Scope
- user display-name consumers
- access ability, permission directive, and route meta typing
- approval utility guardrails
- profile settings presentation cleanup

## Test Plan
- `pnpm exec vitest run src/modules/user/application/__tests__/displayName.spec.ts src/modules/approval/application/__tests__/utils.spec.ts src/directives/__tests__/permission.spec.ts src/modules/access/application/__tests__/ability.spec.ts`
