### PR TITLE
chore(runtime): require Node.js 24 and align CI

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -9,11 +9,11 @@ on:
       upload_sourcemaps:
         description: 是否上传 sourcemap（需配置仓库 Secret）
         required: true
-        default: "false"
+        default: 'false'
         type: choice
         options:
-          - "false"
-          - "true"
+          - 'false'
+          - 'true'
 
 permissions:
   contents: read
@@ -39,7 +39,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
 
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
 
       - name: Install dependencies

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "engines": {
-    "node": "^20.19.0 || >=22.12.0"
+    "node": "^24.0.0"
   },
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- raise runtime requirement to Node.js 24
- align CI/CD workflow node versions with the runtime baseline
- keep local and pipeline execution environments consistent

## Scope
- `package.json`
- `.github/workflows/ci.yml`
- `.github/workflows/cd.yml`

## Test Plan
- `git diff --check dev...HEAD`
