### PR TITLE
fix(request): handle oauth business-code retries and success fallback

### DIFF
--- a/src/app/plugins/useRequestPlugin.ts
+++ b/src/app/plugins/useRequestPlugin.ts
@@ -275,11 +275,25 @@ const globalSuccessHandler = (
       })
       .otherwise(() => {
         if (toastOnErrorConfig) {
+          const successDetail = (() => {
+            if (!data || typeof data !== 'object') {
+              return undefined
+            }
+
+            if ('config' in data && 'data' in data) {
+              return (data as AxiosResponse<RFC7807Response<unknown>>).data?.detail
+            }
+
+            if ('detail' in data) {
+              return (data as RFC7807Response<unknown>).detail
+            }
+
+            return undefined
+          })()
+
           notification.success({
             title: $t('common.status.success'),
-            content: data.hasOwnProperty('config')
-              ? (data as AxiosResponse<RFC7807Response<unknown>>).data.detail
-              : (data as RFC7807Response<unknown>).detail,
+            content: successDetail ?? $t('common.status.success'),
             duration: 5000,
             keepAliveOnHover: true,
           })

--- a/src/modules/shared/infrastructure/__tests__/useRequest.behavior.spec.ts
+++ b/src/modules/shared/infrastructure/__tests__/useRequest.behavior.spec.ts
@@ -3,6 +3,9 @@ import AxiosMockAdapter from 'axios-mock-adapter'
 import { useRequest } from '@/modules/shared/infrastructure/useRequest'
 import { apiClient } from '@/app/infrastructure/request/http-client'
 import { BusinessError } from '@/modules/shared/domain/errors'
+import { ResponseCode } from '@/modules/shared/application/constants/response-code'
+import { AUTH_ENDPOINTS } from '@/modules/access/infrastructure/auth-endpoints'
+import { STORAGE_KEYS } from '@/constants/storage'
 
 let mock: AxiosMockAdapter
 
@@ -185,5 +188,69 @@ describe('useRequest behavior branches', () => {
 
     expect(result.requestId).toBe('request-id-lowercase')
     expect(result.data.value).toBe(1)
+  })
+
+  it('retries with refresh token on token-expired business code and replays request', async () => {
+    localStorage.setItem(STORAGE_KEYS.ACCESS_TOKEN, 'access-old')
+    localStorage.setItem(STORAGE_KEYS.REFRESH_TOKEN, 'refresh-valid')
+
+    let secureRequestCount = 0
+    mock.onGet('/secure-retry').reply((config) => {
+      secureRequestCount += 1
+
+      if (secureRequestCount === 1) {
+        expect(config.headers?.Authorization).toBe('access-old')
+        return [
+          401,
+          {
+            type: 'about:blank',
+            title: 'token expired',
+            status: 401,
+            detail: 'access token expired',
+            code: ResponseCode.OAUTH2_TOKEN_EXPIRED,
+            traceId: 'trace-expired',
+          },
+        ]
+      }
+
+      expect(config.headers?.Authorization).toBe('access-new')
+      return [
+        200,
+        {
+          type: 'about:blank',
+          title: 'ok',
+          status: 200,
+          detail: 'ok',
+          code: 0,
+          traceId: 'trace-replayed',
+          data: { ok: true },
+        },
+      ]
+    })
+
+    mock.onPost(AUTH_ENDPOINTS.TOKEN_REFRESH).reply(200, {
+      type: 'about:blank',
+      title: 'ok',
+      status: 200,
+      detail: 'ok',
+      code: 0,
+      traceId: 'trace-refresh',
+      data: {
+        accessToken: 'access-new',
+        refreshToken: 'refresh-new',
+        expiresIn: 3600,
+      },
+    })
+
+    const result = await useRequest<{ ok: boolean }>({
+      method: 'GET',
+      url: '/secure-retry',
+    })
+
+    expect(result.ok).toBe(true)
+    expect(secureRequestCount).toBe(2)
+    expect(localStorage.getItem(STORAGE_KEYS.ACCESS_TOKEN)).toBe('access-new')
+    expect(localStorage.getItem(STORAGE_KEYS.REFRESH_TOKEN)).toBe('refresh-new')
+    expect(mock.history.post).toHaveLength(1)
   })
 })

--- a/src/modules/shared/infrastructure/useRequest.ts
+++ b/src/modules/shared/infrastructure/useRequest.ts
@@ -20,6 +20,7 @@ import {
   hasStoredRefreshToken,
   isLogoutInProgress,
 } from '@/modules/access/application/token-manager'
+import { ResponseCode } from '@/modules/shared/application/constants/response-code'
 
 export function useRequest<T, D = unknown>(
   config: CustomAxiosRequestConfig<D> & { responseShape: 'data' },
@@ -103,7 +104,12 @@ function shouldRetryWithTokenRefresh(error: unknown, config: CustomAxiosRequestC
   const status = error.response.status ?? problemDetails?.status
   const code = problemDetails?.code
 
-  return status === 401 || code === 401
+  return (
+    status === 401 ||
+    code === 401 ||
+    code === ResponseCode.OAUTH2_TOKEN_VERIFY_ERROR ||
+    code === ResponseCode.OAUTH2_TOKEN_EXPIRED
+  )
 }
 
 function shouldRefreshBeforeRetry(config: CustomAxiosRequestConfig): boolean {


### PR DESCRIPTION
## Summary
- retry request replay when OAuth token failures surface as business codes
- add coverage for refresh-and-replay behavior in `useRequest`
- fall back to generic success copy when global success notifications have no detail payload

## Scope
- `src/modules/shared/infrastructure/useRequest.ts`
- `src/modules/shared/infrastructure/__tests__/useRequest.behavior.spec.ts`
- `src/app/plugins/useRequestPlugin.ts`

## Test Plan
- `pnpm exec vitest run src/modules/shared/infrastructure/__tests__/useRequest.behavior.spec.ts src/app/plugins/__tests__/useRequestPlugin.spec.ts`
