### PR TITLE
refactor: restructure work order detail presentation

### DIFF
--- a/src/modules/work-order/application/hooks/__tests__/useWorkOrderDetailState.spec.ts
+++ b/src/modules/work-order/application/hooks/__tests__/useWorkOrderDetailState.spec.ts
@@ -1,0 +1,176 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { computed, ref, shallowRef } from 'vue'
+import {
+  useHandlerDetail,
+  useHandlerReplies,
+  useWorkOrderDetail,
+  useWorkOrderReplies,
+} from '@/modules/work-order/application/hooks/useWorkOrderService'
+import { useWorkOrderDetailState } from '@/modules/work-order/application/hooks/useWorkOrderDetailState'
+import { WorkOrderStatus, WorkOrderUserType } from '@/modules/work-order/domain/enums'
+import type { WorkOrderDetailVO, WorkOrderReplyVO } from '@/modules/work-order/domain/types'
+
+vi.mock('@/modules/work-order/application/hooks/useWorkOrderService', () => ({
+  useWorkOrderDetail: vi.fn(),
+  useHandlerDetail: vi.fn(),
+  useWorkOrderReplies: vi.fn(),
+  useHandlerReplies: vi.fn(),
+}))
+
+type QueryLike<TData> = {
+  data: { value: TData | undefined }
+  isLoading: { value: boolean }
+}
+
+type EnabledOption = {
+  enabled: { value: boolean }
+}
+
+const createQuery = <TData>(data: TData | undefined): QueryLike<TData> => ({
+  data: shallowRef(data),
+  isLoading: ref(false),
+})
+
+const createDetail = (overrides: Partial<WorkOrderDetailVO> = {}): WorkOrderDetailVO => ({
+  id: 11,
+  categoryId: 2,
+  categoryName: '电表',
+  userId: 9,
+  userName: null,
+  currentHandlerId: 7,
+  currentHandlerName: null,
+  title: '工单标题',
+  status: WorkOrderStatus.PROCESSING,
+  score: null,
+  scoreDeadline: null,
+  completedAt: null,
+  createdTime: '2026-03-17T10:00:00+08:00',
+  updatedTime: '2026-03-17T10:00:00+08:00',
+  content: '工单内容',
+  ...overrides,
+})
+
+const createReply = (overrides: Partial<WorkOrderReplyVO> = {}): WorkOrderReplyVO => ({
+  id: 1,
+  workOrderId: 11,
+  userId: 9,
+  userName: null,
+  userType: WorkOrderUserType.USER,
+  content: '补充说明',
+  createdTime: '2026-03-17T10:00:00+08:00',
+  ...overrides,
+})
+
+const latestEnabledValue = (mockedHook: ReturnType<typeof vi.fn>) => {
+  const latestCall = mockedHook.mock.calls.at(-1)
+  if (!latestCall) {
+    throw new Error('hook should be called before reading enabled option')
+  }
+
+  return (latestCall[1] as EnabledOption).enabled.value
+}
+
+describe('useWorkOrderDetailState', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('selects user-side detail and replies for a non-handler owner', () => {
+    const userDetail = createDetail({
+      userId: 9,
+      userName: null,
+      currentHandlerId: 7,
+      currentHandlerName: null,
+    })
+    const handlerDetail = createDetail({
+      id: 12,
+      title: '处理人详情不应被选中',
+    })
+    const userReplies = [createReply({ userId: 9, userName: null })]
+    const handlerReplies = [createReply({ id: 2, userId: 7, userName: 'Handler' })]
+
+    const userDetailQuery = createQuery(userDetail)
+    const handlerDetailQuery = createQuery(handlerDetail)
+    const userRepliesQuery = createQuery(userReplies)
+    const handlerRepliesQuery = createQuery(handlerReplies)
+
+    vi.mocked(useWorkOrderDetail).mockReturnValue(userDetailQuery as never)
+    vi.mocked(useHandlerDetail).mockReturnValue(handlerDetailQuery as never)
+    vi.mocked(useWorkOrderReplies).mockReturnValue(userRepliesQuery as never)
+    vi.mocked(useHandlerReplies).mockReturnValue(handlerRepliesQuery as never)
+
+    const workOrderId = ref(11)
+    const currentUserId = ref(9)
+    const state = useWorkOrderDetailState({
+      workOrderId,
+      isHandler: ref(false),
+      currentUserId,
+      currentUserDisplayName: computed(() => 'Current Alice'),
+      isOwner: (ownerId) => ownerId === currentUserId.value,
+    })
+
+    expect(latestEnabledValue(vi.mocked(useWorkOrderDetail))).toBe(true)
+    expect(latestEnabledValue(vi.mocked(useHandlerDetail))).toBe(false)
+    expect(latestEnabledValue(vi.mocked(useWorkOrderReplies))).toBe(true)
+    expect(latestEnabledValue(vi.mocked(useHandlerReplies))).toBe(false)
+    expect(state.detailQuery.value).toBe(userDetailQuery)
+    expect(state.detail.value).toStrictEqual(userDetail)
+    expect(state.replyApiMode.value).toBe('user')
+    expect(state.repliesQuery.value).toBe(userRepliesQuery)
+    expect(state.replies.value).toStrictEqual(userReplies)
+    expect(state.canReject.value).toBe(true)
+    expect(state.canReplyAsHandler.value).toBe(false)
+    expect(state.initiatorName.value).toBe('Current Alice')
+    expect(state.claimerName.value).toBe('#7')
+    expect(state.replyAuthorName(userReplies[0])).toBe('Current Alice')
+  })
+
+  it('selects handler-side detail and replies for a current handler', () => {
+    const userDetail = createDetail({
+      id: 12,
+      title: '用户详情不应被选中',
+    })
+    const handlerDetail = createDetail({
+      userId: 9,
+      userName: 'Requester # 3',
+      currentHandlerId: 7,
+      currentHandlerName: null,
+    })
+    const userReplies = [createReply({ id: 2, userId: 9, userName: 'Requester' })]
+    const handlerReplies = [createReply({ userId: 7, userName: null })]
+
+    const userDetailQuery = createQuery(userDetail)
+    const handlerDetailQuery = createQuery(handlerDetail)
+    const userRepliesQuery = createQuery(userReplies)
+    const handlerRepliesQuery = createQuery(handlerReplies)
+
+    vi.mocked(useWorkOrderDetail).mockReturnValue(userDetailQuery as never)
+    vi.mocked(useHandlerDetail).mockReturnValue(handlerDetailQuery as never)
+    vi.mocked(useWorkOrderReplies).mockReturnValue(userRepliesQuery as never)
+    vi.mocked(useHandlerReplies).mockReturnValue(handlerRepliesQuery as never)
+
+    const state = useWorkOrderDetailState({
+      workOrderId: ref(11),
+      isHandler: ref(true),
+      currentUserId: ref(7),
+      currentUserDisplayName: computed(() => 'Current Handler'),
+      isOwner: (ownerId) => ownerId === 7,
+    })
+
+    expect(latestEnabledValue(vi.mocked(useWorkOrderDetail))).toBe(false)
+    expect(latestEnabledValue(vi.mocked(useHandlerDetail))).toBe(true)
+    expect(latestEnabledValue(vi.mocked(useWorkOrderReplies))).toBe(false)
+    expect(latestEnabledValue(vi.mocked(useHandlerReplies))).toBe(true)
+    expect(state.detailQuery.value).toBe(handlerDetailQuery)
+    expect(state.detail.value).toStrictEqual(handlerDetail)
+    expect(state.replyApiMode.value).toBe('handler')
+    expect(state.repliesQuery.value).toBe(handlerRepliesQuery)
+    expect(state.replies.value).toStrictEqual(handlerReplies)
+    expect(state.canReplyAsHandler.value).toBe(true)
+    expect(state.canRelease.value).toBe(true)
+    expect(state.canComplete.value).toBe(true)
+    expect(state.initiatorName.value).toBe('Requester#3')
+    expect(state.claimerName.value).toBe('Current Handler')
+    expect(state.replyAuthorName(handlerReplies[0])).toBe('Current Handler')
+  })
+})

--- a/src/modules/work-order/application/hooks/useWorkOrderDetailState.ts
+++ b/src/modules/work-order/application/hooks/useWorkOrderDetailState.ts
@@ -1,0 +1,132 @@
+import { computed, type ComputedRef, type Ref } from 'vue'
+import type { WorkOrderReplyVO } from '../../domain/types'
+import {
+  useHandlerDetail,
+  useHandlerReplies,
+  useWorkOrderDetail,
+  useWorkOrderReplies,
+} from './useWorkOrderService'
+import {
+  resolveWorkOrderDetailPermissions,
+  resolveWorkOrderReplyApiMode,
+} from '../rules/workOrderDetailRules'
+import {
+  resolveWorkOrderHandlerName,
+  resolveWorkOrderReplyAuthorName,
+  resolveWorkOrderUserName,
+} from '../rules/workOrderParticipantRules'
+
+type UseWorkOrderDetailStateInput = {
+  workOrderId: Ref<number>
+  isHandler: Ref<boolean>
+  currentUserId: Ref<number>
+  currentUserDisplayName: ComputedRef<string> | Ref<string>
+  isOwner: (ownerId: number | undefined) => boolean
+}
+
+export function useWorkOrderDetailState({
+  workOrderId,
+  isHandler,
+  currentUserId,
+  currentUserDisplayName,
+  isOwner: resolveIsOwner,
+}: UseWorkOrderDetailStateInput) {
+  const userDetailQuery = useWorkOrderDetail(workOrderId, {
+    enabled: computed(() => !isHandler.value),
+  })
+  const handlerDetailQuery = useHandlerDetail(workOrderId, { enabled: isHandler })
+  const detailQuery = computed(() => (isHandler.value ? handlerDetailQuery : userDetailQuery))
+  const detail = computed(() => detailQuery.value.data.value)
+
+  const isOwner = computed(() => detail.value && resolveIsOwner(detail.value.userId))
+  const isCurrentHandler = computed(
+    () => detail.value && detail.value.currentHandlerId === currentUserId.value,
+  )
+
+  const permissions = computed(() =>
+    resolveWorkOrderDetailPermissions({
+      detail: detail.value,
+      isHandler: isHandler.value,
+      isOwner: !!isOwner.value,
+      isCurrentHandler: !!isCurrentHandler.value,
+    }),
+  )
+
+  const canReplyAsHandler = computed(() => permissions.value.canReplyAsHandler)
+
+  const replyApiMode = computed<'user' | 'handler' | null>(() =>
+    resolveWorkOrderReplyApiMode({
+      workOrderId: workOrderId.value,
+      detail: detail.value,
+      isHandler: isHandler.value,
+      isOwner: !!isOwner.value,
+      canReplyAsHandler: canReplyAsHandler.value,
+    }),
+  )
+
+  const userRepliesQuery = useWorkOrderReplies(workOrderId, {
+    enabled: computed(() => replyApiMode.value === 'user'),
+  })
+  const handlerRepliesQuery = useHandlerReplies(workOrderId, {
+    enabled: computed(() => replyApiMode.value === 'handler'),
+  })
+  const repliesQuery = computed(() =>
+    replyApiMode.value === 'handler' ? handlerRepliesQuery : userRepliesQuery,
+  )
+  const replies = computed(() => repliesQuery.value.data.value ?? [])
+
+  const initiatorName = computed(() => {
+    if (!detail.value) return '-'
+    return resolveWorkOrderUserName({
+      userId: detail.value.userId,
+      userName: detail.value.userName,
+      currentUserId: currentUserId.value,
+      currentUserDisplayName: currentUserDisplayName.value,
+    })
+  })
+
+  const claimerName = computed(() => {
+    if (!detail.value) return null
+    return resolveWorkOrderHandlerName({
+      currentHandlerId: detail.value.currentHandlerId,
+      currentHandlerName: detail.value.currentHandlerName,
+      currentUserId: currentUserId.value,
+      currentUserDisplayName: currentUserDisplayName.value,
+    })
+  })
+
+  const replyAuthorName = (reply: WorkOrderReplyVO) =>
+    resolveWorkOrderReplyAuthorName({
+      userId: reply.userId,
+      userName: reply.userName,
+      currentUserId: currentUserId.value,
+      currentUserDisplayName: currentUserDisplayName.value,
+    })
+
+  return {
+    userDetailQuery,
+    handlerDetailQuery,
+    detailQuery,
+    detail,
+    isOwner,
+    isCurrentHandler,
+    permissions,
+    canReplyAsHandler,
+    replyApiMode,
+    userRepliesQuery,
+    handlerRepliesQuery,
+    repliesQuery,
+    replies,
+    canReply: computed(() => permissions.value.canReply),
+    canCancel: computed(() => permissions.value.canCancel),
+    canComplete: computed(() => permissions.value.canComplete),
+    canReopen: computed(() => permissions.value.canReopen),
+    canReject: computed(() => permissions.value.canReject),
+    canClaim: computed(() => permissions.value.canClaim),
+    canRelease: computed(() => permissions.value.canRelease),
+    canScore: computed(() => permissions.value.canScore),
+    initiatorName,
+    claimerName,
+    replyAuthorName,
+  }
+}

--- a/src/modules/work-order/application/rules/__tests__/workOrderDetailRules.spec.ts
+++ b/src/modules/work-order/application/rules/__tests__/workOrderDetailRules.spec.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from 'vitest'
+import {
+  resolveWorkOrderDetailPermissions,
+  resolveWorkOrderReplyApiMode,
+} from '@/modules/work-order/application/rules/workOrderDetailRules'
+import { WorkOrderStatus } from '@/modules/work-order/domain/enums'
+
+describe('workOrderDetailRules', () => {
+  it('disables all detail actions when detail is unavailable', () => {
+    expect(
+      resolveWorkOrderDetailPermissions({
+        detail: null,
+        isHandler: true,
+        isOwner: true,
+        isCurrentHandler: true,
+      }),
+    ).toEqual({
+      canReplyAsHandler: false,
+      canReplyAsUser: false,
+      canReply: false,
+      canCancel: false,
+      canComplete: false,
+      canReopen: false,
+      canReject: false,
+      canClaim: false,
+      canRelease: false,
+      canScore: false,
+    })
+  })
+
+  it('allows a current handler to reply, complete and release a processing work order', () => {
+    const permissions = resolveWorkOrderDetailPermissions({
+      detail: {
+        status: WorkOrderStatus.PROCESSING,
+        currentHandlerId: 7,
+      },
+      isHandler: true,
+      isOwner: false,
+      isCurrentHandler: true,
+    })
+
+    expect(permissions).toMatchObject({
+      canReplyAsHandler: true,
+      canReplyAsUser: false,
+      canReply: true,
+      canCancel: false,
+      canComplete: true,
+      canReopen: false,
+      canReject: false,
+      canClaim: false,
+      canRelease: true,
+      canScore: false,
+    })
+  })
+
+  it('allows an owner to manage user-side actions according to status', () => {
+    expect(
+      resolveWorkOrderDetailPermissions({
+        detail: {
+          status: WorkOrderStatus.PROCESSING,
+          currentHandlerId: 7,
+        },
+        isHandler: false,
+        isOwner: true,
+        isCurrentHandler: false,
+      }),
+    ).toMatchObject({
+      canReplyAsHandler: false,
+      canReplyAsUser: true,
+      canReply: true,
+      canCancel: true,
+      canComplete: true,
+      canReject: true,
+      canScore: false,
+    })
+
+    expect(
+      resolveWorkOrderDetailPermissions({
+        detail: {
+          status: WorkOrderStatus.CANCELLED,
+          currentHandlerId: null,
+        },
+        isHandler: false,
+        isOwner: true,
+        isCurrentHandler: false,
+      }),
+    ).toMatchObject({
+      canReply: false,
+      canCancel: false,
+      canReopen: true,
+    })
+
+    expect(
+      resolveWorkOrderDetailPermissions({
+        detail: {
+          status: WorkOrderStatus.COMPLETED,
+          currentHandlerId: 7,
+        },
+        isHandler: false,
+        isOwner: true,
+        isCurrentHandler: false,
+      }),
+    ).toMatchObject({
+      canReply: false,
+      canCancel: false,
+      canComplete: false,
+      canScore: true,
+    })
+  })
+
+  it('allows handler claim only for pending work orders', () => {
+    expect(
+      resolveWorkOrderDetailPermissions({
+        detail: {
+          status: WorkOrderStatus.PENDING,
+          currentHandlerId: null,
+        },
+        isHandler: true,
+        isOwner: false,
+        isCurrentHandler: false,
+      }).canClaim,
+    ).toBe(true)
+
+    expect(
+      resolveWorkOrderDetailPermissions({
+        detail: {
+          status: WorkOrderStatus.PROCESSING,
+          currentHandlerId: 7,
+        },
+        isHandler: true,
+        isOwner: false,
+        isCurrentHandler: false,
+      }).canClaim,
+    ).toBe(false)
+  })
+
+  it('resolves reply API mode without requiring UI state', () => {
+    expect(
+      resolveWorkOrderReplyApiMode({
+        workOrderId: 11,
+        detail: null,
+        isHandler: false,
+        isOwner: false,
+        canReplyAsHandler: false,
+      }),
+    ).toBe('user')
+
+    expect(
+      resolveWorkOrderReplyApiMode({
+        workOrderId: 11,
+        detail: {
+          status: WorkOrderStatus.PROCESSING,
+          currentHandlerId: 7,
+        },
+        isHandler: true,
+        isOwner: false,
+        canReplyAsHandler: false,
+      }),
+    ).toBe('handler')
+
+    expect(
+      resolveWorkOrderReplyApiMode({
+        workOrderId: 11,
+        detail: {
+          status: WorkOrderStatus.PROCESSING,
+          currentHandlerId: 7,
+        },
+        isHandler: true,
+        isOwner: true,
+        canReplyAsHandler: false,
+      }),
+    ).toBe('user')
+
+    expect(
+      resolveWorkOrderReplyApiMode({
+        workOrderId: 0,
+        detail: {
+          status: WorkOrderStatus.PROCESSING,
+          currentHandlerId: 7,
+        },
+        isHandler: false,
+        isOwner: true,
+        canReplyAsHandler: false,
+      }),
+    ).toBeNull()
+  })
+})

--- a/src/modules/work-order/application/rules/__tests__/workOrderParticipantRules.spec.ts
+++ b/src/modules/work-order/application/rules/__tests__/workOrderParticipantRules.spec.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest'
+import {
+  resolveWorkOrderHandlerName,
+  resolveWorkOrderReplyAuthorName,
+  resolveWorkOrderUserName,
+} from '@/modules/work-order/application/rules/workOrderParticipantRules'
+
+describe('workOrderParticipantRules', () => {
+  it('uses backend initiator name before current user fallback and id fallback', () => {
+    expect(
+      resolveWorkOrderUserName({
+        userId: 11,
+        userName: 'Alice # 20',
+        currentUserId: 11,
+        currentUserDisplayName: 'Current Alice',
+      }),
+    ).toBe('Alice#20')
+
+    expect(
+      resolveWorkOrderUserName({
+        userId: 11,
+        userName: null,
+        currentUserId: 11,
+        currentUserDisplayName: 'Current Alice',
+      }),
+    ).toBe('Current Alice')
+
+    expect(
+      resolveWorkOrderUserName({
+        userId: 11,
+        userName: null,
+        currentUserId: 5,
+        currentUserDisplayName: 'Current Alice',
+      }),
+    ).toBe('#11')
+  })
+
+  it('returns null for missing handler and resolves handler fallbacks when claimed', () => {
+    expect(
+      resolveWorkOrderHandlerName({
+        currentHandlerId: null,
+        currentHandlerName: null,
+        currentUserId: 7,
+        currentUserDisplayName: 'Current Handler',
+      }),
+    ).toBeNull()
+
+    expect(
+      resolveWorkOrderHandlerName({
+        currentHandlerId: 7,
+        currentHandlerName: 'Handler # 8',
+        currentUserId: 7,
+        currentUserDisplayName: 'Current Handler',
+      }),
+    ).toBe('Handler#8')
+
+    expect(
+      resolveWorkOrderHandlerName({
+        currentHandlerId: 7,
+        currentHandlerName: null,
+        currentUserId: 7,
+        currentUserDisplayName: 'Current Handler',
+      }),
+    ).toBe('Current Handler')
+
+    expect(
+      resolveWorkOrderHandlerName({
+        currentHandlerId: 7,
+        currentHandlerName: null,
+        currentUserId: 5,
+        currentUserDisplayName: 'Current Handler',
+      }),
+    ).toBe('#7')
+  })
+
+  it('uses reply user name before current user fallback and id fallback', () => {
+    expect(
+      resolveWorkOrderReplyAuthorName({
+        userId: 9,
+        userName: 'Reply User # 12',
+        currentUserId: 9,
+        currentUserDisplayName: 'Current Reply User',
+      }),
+    ).toBe('Reply User#12')
+
+    expect(
+      resolveWorkOrderReplyAuthorName({
+        userId: 9,
+        userName: null,
+        currentUserId: 9,
+        currentUserDisplayName: 'Current Reply User',
+      }),
+    ).toBe('Current Reply User')
+
+    expect(
+      resolveWorkOrderReplyAuthorName({
+        userId: 9,
+        userName: null,
+        currentUserId: 5,
+        currentUserDisplayName: 'Current Reply User',
+      }),
+    ).toBe('#9')
+  })
+})

--- a/src/modules/work-order/application/rules/workOrderDetailRules.ts
+++ b/src/modules/work-order/application/rules/workOrderDetailRules.ts
@@ -1,0 +1,100 @@
+import { WorkOrderStatus } from '@/modules/work-order/domain/enums'
+
+type WorkOrderDetailPermissionInput = {
+  detail:
+    | {
+        status: WorkOrderStatus
+        currentHandlerId: number | null
+      }
+    | null
+    | undefined
+  isHandler: boolean
+  isOwner: boolean
+  isCurrentHandler: boolean
+}
+
+export type WorkOrderDetailPermissions = {
+  canReplyAsHandler: boolean
+  canReplyAsUser: boolean
+  canReply: boolean
+  canCancel: boolean
+  canComplete: boolean
+  canReopen: boolean
+  canReject: boolean
+  canClaim: boolean
+  canRelease: boolean
+  canScore: boolean
+}
+
+const emptyWorkOrderDetailPermissions: WorkOrderDetailPermissions = {
+  canReplyAsHandler: false,
+  canReplyAsUser: false,
+  canReply: false,
+  canCancel: false,
+  canComplete: false,
+  canReopen: false,
+  canReject: false,
+  canClaim: false,
+  canRelease: false,
+  canScore: false,
+}
+
+export function resolveWorkOrderDetailPermissions({
+  detail,
+  isHandler,
+  isOwner,
+  isCurrentHandler,
+}: WorkOrderDetailPermissionInput): WorkOrderDetailPermissions {
+  if (!detail) {
+    return emptyWorkOrderDetailPermissions
+  }
+
+  const status = detail?.status
+
+  const canReplyAsHandler = isHandler && isCurrentHandler && status === WorkOrderStatus.PROCESSING
+
+  const canReplyAsUser =
+    status !== WorkOrderStatus.COMPLETED &&
+    status !== WorkOrderStatus.CANCELLED &&
+    (!isHandler || isOwner)
+
+  return {
+    canReplyAsHandler,
+    canReplyAsUser,
+    canReply: canReplyAsHandler || canReplyAsUser,
+    canCancel:
+      isOwner && status !== WorkOrderStatus.CANCELLED && status !== WorkOrderStatus.COMPLETED,
+    canComplete: (isOwner || isCurrentHandler) && status === WorkOrderStatus.PROCESSING,
+    canReopen: isOwner && status === WorkOrderStatus.CANCELLED,
+    canReject: isOwner && status === WorkOrderStatus.PROCESSING && detail?.currentHandlerId != null,
+    canClaim: isHandler && status === WorkOrderStatus.PENDING,
+    canRelease: isHandler && isCurrentHandler && status === WorkOrderStatus.PROCESSING,
+    canScore: isOwner && status === WorkOrderStatus.COMPLETED,
+  }
+}
+
+type WorkOrderReplyApiModeInput = {
+  workOrderId: number
+  detail: WorkOrderDetailPermissionInput['detail']
+  isHandler: boolean
+  isOwner: boolean
+  canReplyAsHandler: boolean
+}
+
+export function resolveWorkOrderReplyApiMode({
+  workOrderId,
+  detail,
+  isHandler,
+  isOwner,
+  canReplyAsHandler,
+}: WorkOrderReplyApiModeInput): 'user' | 'handler' | null {
+  if (!workOrderId) return null
+  if (!isHandler) return 'user'
+  if (!detail) return null
+
+  if (canReplyAsHandler || !isOwner) {
+    return 'handler'
+  }
+
+  return 'user'
+}

--- a/src/modules/work-order/application/rules/workOrderParticipantRules.ts
+++ b/src/modules/work-order/application/rules/workOrderParticipantRules.ts
@@ -1,0 +1,55 @@
+import { resolveUserDisplayName } from '@/modules/user/application/utils/displayName'
+
+type WorkOrderParticipantNameInput = {
+  userId: number
+  userName?: string | null
+  currentUserId: number
+  currentUserDisplayName: string
+}
+
+type WorkOrderHandlerNameInput = {
+  currentHandlerId: number | null
+  currentHandlerName?: string | null
+  currentUserId: number
+  currentUserDisplayName: string
+}
+
+function resolveParticipantName({
+  userId,
+  userName,
+  currentUserId,
+  currentUserDisplayName,
+}: WorkOrderParticipantNameInput) {
+  const displayName = resolveUserDisplayName({ name: userName })
+  if (displayName) return displayName
+
+  if (userId === currentUserId && currentUserDisplayName) {
+    return currentUserDisplayName
+  }
+
+  return `#${userId}`
+}
+
+export function resolveWorkOrderUserName(input: WorkOrderParticipantNameInput) {
+  return resolveParticipantName(input)
+}
+
+export function resolveWorkOrderReplyAuthorName(input: WorkOrderParticipantNameInput) {
+  return resolveParticipantName(input)
+}
+
+export function resolveWorkOrderHandlerName({
+  currentHandlerId,
+  currentHandlerName,
+  currentUserId,
+  currentUserDisplayName,
+}: WorkOrderHandlerNameInput) {
+  if (currentHandlerId == null) return null
+
+  return resolveParticipantName({
+    userId: currentHandlerId,
+    userName: currentHandlerName,
+    currentUserId,
+    currentUserDisplayName,
+  })
+}

--- a/src/modules/work-order/presentation/WorkOrderDetailActions.tsx
+++ b/src/modules/work-order/presentation/WorkOrderDetailActions.tsx
@@ -1,0 +1,132 @@
+import { defineComponent } from 'vue'
+import { NButton, NInput, NPopconfirm, NSpace } from 'naive-ui'
+import { useI18n } from 'vue-i18n'
+
+export default defineComponent({
+  name: 'WorkOrderDetailActions',
+  props: {
+    canClaim: {
+      type: Boolean,
+      default: false,
+    },
+    canRelease: {
+      type: Boolean,
+      default: false,
+    },
+    canComplete: {
+      type: Boolean,
+      default: false,
+    },
+    canReopen: {
+      type: Boolean,
+      default: false,
+    },
+    canReject: {
+      type: Boolean,
+      default: false,
+    },
+    claimLoading: {
+      type: Boolean,
+      default: false,
+    },
+    releaseLoading: {
+      type: Boolean,
+      default: false,
+    },
+    rejectRemark: {
+      type: String,
+      default: '',
+    },
+  },
+  emits: {
+    claim: () => true,
+    release: () => true,
+    complete: () => true,
+    reopen: () => true,
+    reject: () => true,
+    'update:rejectRemark': (_value: string) => true,
+  },
+  setup(props, { emit }) {
+    const { t: $t } = useI18n()
+
+    return () => (
+      <NSpace size={8}>
+        {props.canClaim && (
+          <NPopconfirm
+            onPositiveClick={() => emit('claim')}
+            v-slots={{
+              trigger: () => (
+                <NButton size="small" type="primary" loading={props.claimLoading}>
+                  {$t('domain.workOrder.action.claim')}
+                </NButton>
+              ),
+              default: () => $t('domain.workOrder.message.claimConfirm'),
+            }}
+          />
+        )}
+
+        {props.canRelease && (
+          <NPopconfirm
+            onPositiveClick={() => emit('release')}
+            v-slots={{
+              trigger: () => (
+                <NButton size="small" loading={props.releaseLoading}>
+                  {$t('domain.workOrder.action.release')}
+                </NButton>
+              ),
+              default: () => $t('domain.workOrder.message.releaseConfirm'),
+            }}
+          />
+        )}
+
+        {props.canComplete && (
+          <NPopconfirm
+            onPositiveClick={() => emit('complete')}
+            v-slots={{
+              trigger: () => (
+                <NButton size="small" type="success">
+                  {$t('domain.workOrder.action.complete')}
+                </NButton>
+              ),
+              default: () => $t('domain.workOrder.message.completeConfirm'),
+            }}
+          />
+        )}
+
+        {props.canReopen && (
+          <NPopconfirm
+            onPositiveClick={() => emit('reopen')}
+            v-slots={{
+              trigger: () => <NButton size="small">{$t('domain.workOrder.action.reopen')}</NButton>,
+              default: () => $t('domain.workOrder.message.reopenConfirm'),
+            }}
+          />
+        )}
+
+        {props.canReject && (
+          <NPopconfirm
+            onPositiveClick={() => emit('reject')}
+            v-slots={{
+              trigger: () => (
+                <NButton size="small" type="error">
+                  {$t('domain.workOrder.action.reject')}
+                </NButton>
+              ),
+              default: () => (
+                <NSpace vertical size={8}>
+                  <span>{$t('domain.workOrder.message.rejectConfirm')}</span>
+                  <NInput
+                    value={props.rejectRemark}
+                    onUpdate:value={(value: string) => emit('update:rejectRemark', value)}
+                    size="small"
+                    placeholder={$t('domain.workOrder.label.rejectRemark')}
+                  />
+                </NSpace>
+              ),
+            }}
+          />
+        )}
+      </NSpace>
+    )
+  },
+})

--- a/src/modules/work-order/presentation/WorkOrderDetailHeader.tsx
+++ b/src/modules/work-order/presentation/WorkOrderDetailHeader.tsx
@@ -1,0 +1,76 @@
+import { defineComponent, type PropType } from 'vue'
+import { NSpace, NText, NTag, NPopconfirm } from 'naive-ui'
+import { useI18n } from 'vue-i18n'
+import type { WorkOrderDetailVO } from '../domain/types'
+import WorkOrderStatusBadge from './WorkOrderStatusBadge'
+import { formatted } from '@/modules/shared/presentation/time'
+
+export default defineComponent({
+  name: 'WorkOrderDetailHeader',
+  props: {
+    detail: {
+      type: Object as PropType<WorkOrderDetailVO>,
+      required: true,
+    },
+    initiatorName: {
+      type: String,
+      required: true,
+    },
+    claimerName: {
+      type: String as PropType<string | null>,
+      default: null,
+    },
+    canCancel: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  emits: {
+    cancel: () => true,
+  },
+  setup(props, { emit }) {
+    const { t: $t } = useI18n()
+
+    return () => (
+      <NSpace vertical size={8}>
+        <NSpace align="center" size={12}>
+          <h2 class="m-0">{props.detail.title}</h2>
+          <WorkOrderStatusBadge status={props.detail.status} />
+          {props.canCancel && (
+            <NPopconfirm
+              onPositiveClick={() => emit('cancel')}
+              v-slots={{
+                trigger: () => (
+                  <NTag size="small" type="warning" round class="cursor-pointer">
+                    {$t('domain.workOrder.action.cancel')}
+                  </NTag>
+                ),
+                default: () => $t('domain.workOrder.message.cancelConfirm'),
+              }}
+            />
+          )}
+        </NSpace>
+        <NSpace size={16}>
+          <NText depth={3}>{props.detail.categoryName}</NText>
+          <NText depth={3}>{formatted(props.detail.createdTime).standard}</NText>
+          {props.detail.completedAt && (
+            <NText depth={3}>
+              {$t('domain.workOrder.label.completedAt')}:{' '}
+              {formatted(props.detail.completedAt).standard}
+            </NText>
+          )}
+        </NSpace>
+        <NSpace size={16}>
+          <NText depth={3}>
+            {$t('domain.workOrder.label.initiator')}: {props.initiatorName}
+          </NText>
+          {props.claimerName && (
+            <NText depth={3}>
+              {$t('domain.workOrder.label.claimer')}: {props.claimerName}
+            </NText>
+          )}
+        </NSpace>
+      </NSpace>
+    )
+  },
+})

--- a/src/modules/work-order/presentation/WorkOrderDetailPage.tsx
+++ b/src/modules/work-order/presentation/WorkOrderDetailPage.tsx
@@ -1,41 +1,27 @@
 import { computed, defineAsyncComponent, defineComponent, h, ref, Suspense } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-import {
-  NSpace,
-  NButton,
-  NDivider,
-  NText,
-  NTag,
-  NCard,
-  NResult,
-  NPopconfirm,
-  NInput,
-  NSpin,
-} from 'naive-ui'
+import { NSpace, NButton, NDivider, NCard, NResult, NSpin } from 'naive-ui'
 import { message } from '@/_utils/discrete_naive_api'
 import { useI18n } from 'vue-i18n'
 import { useAccountStore } from '@/modules/user/application/stores/useAccountStore'
 import {
-  useWorkOrderDetail,
-  useWorkOrderReplies,
   useAddReply,
   useCancelWorkOrder,
   useCompleteWorkOrder,
   useRejectHandler,
   useReopenWorkOrder,
-  useHandlerDetail,
-  useHandlerReplies,
   useHandlerAddReply,
   useClaimWorkOrder,
   useReleaseWorkOrder,
   useHandlerComplete,
 } from '../application/hooks/useWorkOrderService'
+import { useWorkOrderDetailState } from '../application/hooks/useWorkOrderDetailState'
 import { useWorkOrderUpload } from '../application/hooks/useWorkOrderUpload'
-import { WorkOrderStatus, WorkOrderUserType } from '../domain/enums'
-import type { WorkOrderReplyVO } from '../domain/types'
-import WorkOrderStatusBadge from './WorkOrderStatusBadge'
+import WorkOrderDetailActions from './WorkOrderDetailActions'
+import WorkOrderDetailHeader from './WorkOrderDetailHeader'
+import WorkOrderReplyEditor from './WorkOrderReplyEditor'
+import WorkOrderReplyList from './WorkOrderReplyList'
 import WorkOrderScoreSection from './WorkOrderScoreSection'
-import { formatted } from '@/modules/shared/presentation/time'
 import { resolveUserDisplayName } from '@/modules/user/application/utils/displayName'
 import { loadMdEditor, loadMdPreview } from './md-editor-loader'
 import './styles/WorkOrderDetailPage.css'
@@ -67,13 +53,29 @@ export default defineComponent({
       resolveUserDisplayName({ name: accountStore.user.name }),
     )
 
-    const userDetailQuery = useWorkOrderDetail(workOrderId, {
-      enabled: computed(() => !isHandler.value),
+    const {
+      detailQuery,
+      detail,
+      replies,
+      canReplyAsHandler,
+      canReply,
+      canCancel,
+      canComplete,
+      canReopen,
+      canReject,
+      canClaim,
+      canRelease,
+      canScore,
+      initiatorName,
+      claimerName,
+      replyAuthorName,
+    } = useWorkOrderDetailState({
+      workOrderId,
+      isHandler,
+      currentUserId,
+      currentUserDisplayName,
+      isOwner: accountStore.isOwner,
     })
-    const handlerDetailQuery = useHandlerDetail(workOrderId, { enabled: isHandler })
-    const detailQuery = computed(() => (isHandler.value ? handlerDetailQuery : userDetailQuery))
-
-    const detail = computed(() => detailQuery.value.data.value)
 
     const userAddReply = useAddReply()
     const handlerAddReplyMutation = useHandlerAddReply()
@@ -87,118 +89,6 @@ export default defineComponent({
 
     const replyContent = ref('')
     const rejectRemark = ref('')
-
-    const isOwner = computed(() => detail.value && accountStore.isOwner(detail.value.userId))
-    const isCurrentHandler = computed(
-      () => detail.value && detail.value.currentHandlerId === currentUserId.value,
-    )
-
-    const canReplyAsHandler = computed(() => {
-      if (!detail.value) return false
-      return (
-        isHandler.value &&
-        isCurrentHandler.value &&
-        detail.value.status === WorkOrderStatus.PROCESSING
-      )
-    })
-
-    const canReplyAsUser = computed(() => {
-      if (!detail.value) return false
-      const status = detail.value.status
-      if (status === WorkOrderStatus.COMPLETED || status === WorkOrderStatus.CANCELLED) {
-        return false
-      }
-      return !isHandler.value || isOwner.value
-    })
-
-    const replyApiMode = computed<'user' | 'handler' | null>(() => {
-      if (!workOrderId.value) return null
-      if (!isHandler.value) return 'user'
-      if (!detail.value) return null
-
-      if (canReplyAsHandler.value || !isOwner.value) {
-        return 'handler'
-      }
-
-      return 'user'
-    })
-
-    const userRepliesQuery = useWorkOrderReplies(workOrderId, {
-      enabled: computed(() => replyApiMode.value === 'user'),
-    })
-    const handlerRepliesQuery = useHandlerReplies(workOrderId, {
-      enabled: computed(() => replyApiMode.value === 'handler'),
-    })
-    const repliesQuery = computed(() =>
-      replyApiMode.value === 'handler' ? handlerRepliesQuery : userRepliesQuery,
-    )
-    const replies = computed(() => repliesQuery.value.data.value ?? [])
-
-    const canReply = computed(() => {
-      return canReplyAsHandler.value || canReplyAsUser.value
-    })
-
-    const canCancel = computed(
-      () =>
-        isOwner.value &&
-        detail.value?.status !== WorkOrderStatus.CANCELLED &&
-        detail.value?.status !== WorkOrderStatus.COMPLETED,
-    )
-    const canComplete = computed(
-      () =>
-        (isOwner.value || isCurrentHandler.value) &&
-        detail.value?.status === WorkOrderStatus.PROCESSING,
-    )
-    const canReopen = computed(
-      () => isOwner.value && detail.value?.status === WorkOrderStatus.CANCELLED,
-    )
-    const canReject = computed(
-      () =>
-        isOwner.value &&
-        detail.value?.status === WorkOrderStatus.PROCESSING &&
-        detail.value?.currentHandlerId != null,
-    )
-    const canClaim = computed(
-      () => isHandler.value && detail.value?.status === WorkOrderStatus.PENDING,
-    )
-    const canRelease = computed(
-      () =>
-        isHandler.value &&
-        isCurrentHandler.value &&
-        detail.value?.status === WorkOrderStatus.PROCESSING,
-    )
-    const canScore = computed(
-      () => isOwner.value && detail.value?.status === WorkOrderStatus.COMPLETED,
-    )
-
-    const initiatorName = computed(() => {
-      if (!detail.value) return '-'
-      const detailUserDisplayName = resolveUserDisplayName({ name: detail.value.userName })
-      if (detailUserDisplayName) return detailUserDisplayName
-      if (accountStore.isOwner(detail.value.userId) && currentUserDisplayName.value) {
-        return currentUserDisplayName.value
-      }
-      return `#${detail.value.userId}`
-    })
-
-    const claimerName = computed(() => {
-      if (!detail.value || detail.value.currentHandlerId == null) return null
-      const handlerDisplayName = resolveUserDisplayName({ name: detail.value.currentHandlerName })
-      if (handlerDisplayName) return handlerDisplayName
-      if (detail.value.currentHandlerId === currentUserId.value && currentUserDisplayName.value) {
-        return currentUserDisplayName.value
-      }
-      return `#${detail.value.currentHandlerId}`
-    })
-
-    const replyAuthorName = (reply: WorkOrderReplyVO) => {
-      const replyUserDisplayName = resolveUserDisplayName({ name: reply.userName })
-      if (replyUserDisplayName) return replyUserDisplayName
-      if (reply.userId === currentUserId.value && currentUserDisplayName.value) {
-        return currentUserDisplayName.value
-      }
-      return `#${reply.userId}`
-    }
 
     const handleReply = () => {
       if (!replyContent.value.trim() || !workOrderId.value) return
@@ -272,29 +162,6 @@ export default defineComponent({
       />
     )
 
-    const renderReplyEditor = () => (
-      <Suspense
-        v-slots={{
-          default: () =>
-            h(AsyncMdEditor, {
-              modelValue: replyContent.value,
-              'onUpdate:modelValue': (value: string) => {
-                replyContent.value = value
-              },
-              language: 'zh-CN',
-              class: 'w-full',
-              preview: false,
-              onOnUploadImg: onUploadImg,
-            }),
-          fallback: () => (
-            <NSpin show={true} class="markdown-loading-shell">
-              <div class="markdown-editor-loading-placeholder" />
-            </NSpin>
-          ),
-        }}
-      />
-    )
-
     return () => {
       const currentDetail = detail.value
 
@@ -317,128 +184,32 @@ export default defineComponent({
         <NSpin show={detailQuery.value.isLoading.value}>
           {currentDetail ? (
             <NSpace class="work-order-detail-page" vertical size={24}>
-              <NSpace vertical size={8}>
-                <NSpace align="center" size={12}>
-                  <h2 class="m-0">{currentDetail.title}</h2>
-                  <WorkOrderStatusBadge status={currentDetail.status} />
-                  {canCancel.value && (
-                    <NPopconfirm
-                      onPositiveClick={handleCancel}
-                      v-slots={{
-                        trigger: () => (
-                          <NTag size="small" type="warning" round class="cursor-pointer">
-                            {$t('domain.workOrder.action.cancel')}
-                          </NTag>
-                        ),
-                        default: () => $t('domain.workOrder.message.cancelConfirm'),
-                      }}
-                    />
-                  )}
-                </NSpace>
-                <NSpace size={16}>
-                  <NText depth={3}>{currentDetail.categoryName}</NText>
-                  <NText depth={3}>{formatted(currentDetail.createdTime).standard}</NText>
-                  {currentDetail.completedAt && (
-                    <NText depth={3}>
-                      {$t('domain.workOrder.label.completedAt')}:{' '}
-                      {formatted(currentDetail.completedAt).standard}
-                    </NText>
-                  )}
-                </NSpace>
-                <NSpace size={16}>
-                  <NText depth={3}>
-                    {$t('domain.workOrder.label.initiator')}: {initiatorName.value}
-                  </NText>
-                  {claimerName.value && (
-                    <NText depth={3}>
-                      {$t('domain.workOrder.label.claimer')}: {claimerName.value}
-                    </NText>
-                  )}
-                </NSpace>
-              </NSpace>
+              <WorkOrderDetailHeader
+                detail={currentDetail}
+                initiatorName={initiatorName.value}
+                claimerName={claimerName.value}
+                canCancel={canCancel.value}
+                onCancel={handleCancel}
+              />
 
-              <NSpace size={8}>
-                {canClaim.value && (
-                  <NPopconfirm
-                    onPositiveClick={handleClaim}
-                    v-slots={{
-                      trigger: () => (
-                        <NButton
-                          size="small"
-                          type="primary"
-                          loading={claimMutation.isPending.value}
-                        >
-                          {$t('domain.workOrder.action.claim')}
-                        </NButton>
-                      ),
-                      default: () => $t('domain.workOrder.message.claimConfirm'),
-                    }}
-                  />
-                )}
-
-                {canRelease.value && (
-                  <NPopconfirm
-                    onPositiveClick={handleRelease}
-                    v-slots={{
-                      trigger: () => (
-                        <NButton size="small" loading={releaseMutation.isPending.value}>
-                          {$t('domain.workOrder.action.release')}
-                        </NButton>
-                      ),
-                      default: () => $t('domain.workOrder.message.releaseConfirm'),
-                    }}
-                  />
-                )}
-
-                {canComplete.value && (
-                  <NPopconfirm
-                    onPositiveClick={handleComplete}
-                    v-slots={{
-                      trigger: () => (
-                        <NButton size="small" type="success">
-                          {$t('domain.workOrder.action.complete')}
-                        </NButton>
-                      ),
-                      default: () => $t('domain.workOrder.message.completeConfirm'),
-                    }}
-                  />
-                )}
-
-                {canReopen.value && (
-                  <NPopconfirm
-                    onPositiveClick={handleReopen}
-                    v-slots={{
-                      trigger: () => (
-                        <NButton size="small">{$t('domain.workOrder.action.reopen')}</NButton>
-                      ),
-                      default: () => $t('domain.workOrder.message.reopenConfirm'),
-                    }}
-                  />
-                )}
-
-                {canReject.value && (
-                  <NPopconfirm
-                    onPositiveClick={handleReject}
-                    v-slots={{
-                      trigger: () => (
-                        <NButton size="small" type="error">
-                          {$t('domain.workOrder.action.reject')}
-                        </NButton>
-                      ),
-                      default: () => (
-                        <NSpace vertical size={8}>
-                          <span>{$t('domain.workOrder.message.rejectConfirm')}</span>
-                          <NInput
-                            v-model:value={rejectRemark.value}
-                            size="small"
-                            placeholder={$t('domain.workOrder.label.rejectRemark')}
-                          />
-                        </NSpace>
-                      ),
-                    }}
-                  />
-                )}
-              </NSpace>
+              <WorkOrderDetailActions
+                canClaim={canClaim.value}
+                canRelease={canRelease.value}
+                canComplete={canComplete.value}
+                canReopen={canReopen.value}
+                canReject={canReject.value}
+                claimLoading={claimMutation.isPending.value}
+                releaseLoading={releaseMutation.isPending.value}
+                rejectRemark={rejectRemark.value}
+                onUpdate:rejectRemark={(value: string) => {
+                  rejectRemark.value = value
+                }}
+                onClaim={handleClaim}
+                onRelease={handleRelease}
+                onComplete={handleComplete}
+                onReopen={handleReopen}
+                onReject={handleReject}
+              />
 
               <NCard bordered={false}>{renderMarkdownPreview(currentDetail.content)}</NCard>
 
@@ -451,52 +222,21 @@ export default defineComponent({
                 />
               )}
 
-              <NSpace vertical size={16}>
-                <h3 class="m-0">
-                  {$t('domain.workOrder.action.reply')} ({replies.value.length})
-                </h3>
-
-                {replies.value.length === 0 && (
-                  <NText depth={3}>{$t('domain.workOrder.message.noReplies')}</NText>
-                )}
-
-                {replies.value.map((reply) => (
-                  <NCard
-                    key={reply.id}
-                    bordered={true}
-                    size="small"
-                    style={{
-                      borderLeft:
-                        reply.userType === WorkOrderUserType.HANDLER
-                          ? '0.25rem solid var(--n-color-target)'
-                          : '0.25rem solid var(--n-border-color)',
-                    }}
-                    v-slots={{
-                      header: () => (
-                        <NSpace align="center" size={8}>
-                          <NText strong>{replyAuthorName(reply)}</NText>
-                          <NText depth={3} class="text-[0.75rem]">
-                            {reply.userType === WorkOrderUserType.HANDLER
-                              ? $t('domain.workOrder.label.handlerReply')
-                              : $t('domain.workOrder.label.userReply')}
-                          </NText>
-                          <NText depth={3} class="text-[0.75rem]">
-                            {formatted(reply.createdTime).standard}
-                          </NText>
-                        </NSpace>
-                      ),
-                      default: () => renderMarkdownPreview(reply.content),
-                    }}
-                  />
-                ))}
-              </NSpace>
+              <WorkOrderReplyList
+                replies={replies.value}
+                replyAuthorName={replyAuthorName}
+                renderMarkdownPreview={renderMarkdownPreview}
+              />
 
               {canReply.value && (
-                <NCard bordered={false}>
-                  <NSpace vertical size={12}>
-                    {renderReplyEditor()}
-                  </NSpace>
-                </NCard>
+                <WorkOrderReplyEditor
+                  editorComponent={AsyncMdEditor}
+                  modelValue={replyContent.value}
+                  onUpdate:modelValue={(value: string) => {
+                    replyContent.value = value
+                  }}
+                  onUploadImg={onUploadImg}
+                />
               )}
 
               <NSpace justify="end">

--- a/src/modules/work-order/presentation/WorkOrderReplyEditor.tsx
+++ b/src/modules/work-order/presentation/WorkOrderReplyEditor.tsx
@@ -1,0 +1,60 @@
+import { defineComponent, h, Suspense, toRaw, type Component, type PropType } from 'vue'
+import { NCard, NSpin, NSpace } from 'naive-ui'
+
+type MarkdownUploadResult = {
+  url: string
+  alt: string
+  title: string
+}
+
+type MarkdownImageUploadHandler = (
+  files: File[],
+  callback: (urls: MarkdownUploadResult[]) => void,
+) => void | Promise<void>
+
+export default defineComponent({
+  name: 'WorkOrderReplyEditor',
+  props: {
+    editorComponent: {
+      type: Object as PropType<Component>,
+      required: true,
+    },
+    modelValue: {
+      type: String,
+      required: true,
+    },
+    onUploadImg: {
+      type: Function as PropType<MarkdownImageUploadHandler>,
+      required: true,
+    },
+  },
+  emits: {
+    'update:modelValue': (_value: string) => true,
+  },
+  setup(props, { emit }) {
+    return () => (
+      <NCard bordered={false}>
+        <NSpace vertical size={12}>
+          <Suspense
+            v-slots={{
+              default: () =>
+                h(toRaw(props.editorComponent), {
+                  modelValue: props.modelValue,
+                  'onUpdate:modelValue': (value: string) => emit('update:modelValue', value),
+                  language: 'zh-CN',
+                  class: 'w-full',
+                  preview: false,
+                  onOnUploadImg: props.onUploadImg,
+                }),
+              fallback: () => (
+                <NSpin show={true} class="markdown-loading-shell">
+                  <div class="markdown-editor-loading-placeholder" />
+                </NSpin>
+              ),
+            }}
+          />
+        </NSpace>
+      </NCard>
+    )
+  },
+})

--- a/src/modules/work-order/presentation/WorkOrderReplyList.tsx
+++ b/src/modules/work-order/presentation/WorkOrderReplyList.tsx
@@ -1,0 +1,69 @@
+import { defineComponent, type PropType, type VNodeChild } from 'vue'
+import { NCard, NSpace, NText } from 'naive-ui'
+import { useI18n } from 'vue-i18n'
+import { WorkOrderUserType } from '../domain/enums'
+import type { WorkOrderReplyVO } from '../domain/types'
+import { formatted } from '@/modules/shared/presentation/time'
+
+export default defineComponent({
+  name: 'WorkOrderReplyList',
+  props: {
+    replies: {
+      type: Array as PropType<WorkOrderReplyVO[]>,
+      required: true,
+    },
+    replyAuthorName: {
+      type: Function as PropType<(reply: WorkOrderReplyVO) => string>,
+      required: true,
+    },
+    renderMarkdownPreview: {
+      type: Function as PropType<(content: string) => VNodeChild>,
+      required: true,
+    },
+  },
+  setup(props) {
+    const { t: $t } = useI18n()
+
+    return () => (
+      <NSpace vertical size={16}>
+        <h3 class="m-0">
+          {$t('domain.workOrder.action.reply')} ({props.replies.length})
+        </h3>
+
+        {props.replies.length === 0 && (
+          <NText depth={3}>{$t('domain.workOrder.message.noReplies')}</NText>
+        )}
+
+        {props.replies.map((reply) => (
+          <NCard
+            key={reply.id}
+            bordered={true}
+            size="small"
+            style={{
+              borderLeft:
+                reply.userType === WorkOrderUserType.HANDLER
+                  ? '0.25rem solid var(--n-color-target)'
+                  : '0.25rem solid var(--n-border-color)',
+            }}
+            v-slots={{
+              header: () => (
+                <NSpace align="center" size={8}>
+                  <NText strong>{props.replyAuthorName(reply)}</NText>
+                  <NText depth={3} class="text-[0.75rem]">
+                    {reply.userType === WorkOrderUserType.HANDLER
+                      ? $t('domain.workOrder.label.handlerReply')
+                      : $t('domain.workOrder.label.userReply')}
+                  </NText>
+                  <NText depth={3} class="text-[0.75rem]">
+                    {formatted(reply.createdTime).standard}
+                  </NText>
+                </NSpace>
+              ),
+              default: () => props.renderMarkdownPreview(reply.content),
+            }}
+          />
+        ))}
+      </NSpace>
+    )
+  },
+})

--- a/src/modules/work-order/presentation/__tests__/WorkOrderDetailActions.spec.ts
+++ b/src/modules/work-order/presentation/__tests__/WorkOrderDetailActions.spec.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it, vi } from 'vitest'
+import { defineComponent, h } from 'vue'
+import { mount } from '@vue/test-utils'
+import WorkOrderDetailActions from '@/modules/work-order/presentation/WorkOrderDetailActions'
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+vi.mock('naive-ui', () => ({
+  NSpace: defineComponent({
+    name: 'NSpace',
+    setup(_, { slots }) {
+      return () => h('div', { 'data-test': 'n-space' }, slots.default?.())
+    },
+  }),
+  NInput: defineComponent({
+    name: 'NInput',
+    inheritAttrs: false,
+    props: {
+      value: {
+        type: String,
+        default: '',
+      },
+      placeholder: {
+        type: String,
+        default: '',
+      },
+    },
+    emits: ['update:value'],
+    setup(props, { emit }) {
+      return () =>
+        h('input', {
+          'data-test': 'reject-remark',
+          value: props.value,
+          placeholder: props.placeholder,
+          onInput: (event: Event) => {
+            emit('update:value', (event.target as HTMLInputElement).value)
+          },
+        })
+    },
+  }),
+  NButton: defineComponent({
+    name: 'NButton',
+    props: {
+      loading: {
+        type: Boolean,
+        default: false,
+      },
+    },
+    emits: ['click'],
+    setup(props, { emit, slots }) {
+      return () =>
+        h(
+          'button',
+          {
+            'data-test': `action-${String(slots.default?.()[0]?.children)}`,
+            'data-loading': String(props.loading),
+            onClick: () => emit('click'),
+          },
+          slots.default?.(),
+        )
+    },
+  }),
+  NPopconfirm: defineComponent({
+    name: 'NPopconfirm',
+    emits: ['positive-click'],
+    setup(_, { emit, slots }) {
+      const resolveConfirmTestId = () => {
+        const defaultSlot = slots.default?.()
+        const firstChild = defaultSlot?.[0]?.children
+        return typeof firstChild === 'string' ? firstChild : 'custom'
+      }
+
+      return () =>
+        h('div', { 'data-test': 'popconfirm' }, [
+          slots.trigger?.(),
+          h(
+            'button',
+            {
+              'data-test': `confirm-${resolveConfirmTestId()}`,
+              onClick: () => emit('positive-click'),
+            },
+            slots.default?.(),
+          ),
+        ])
+    },
+  }),
+}))
+
+describe('WorkOrderDetailActions', () => {
+  it('renders enabled actions and emits command events', async () => {
+    const wrapper = mount(WorkOrderDetailActions, {
+      props: {
+        canClaim: true,
+        canRelease: true,
+        canComplete: true,
+        canReopen: true,
+        canReject: true,
+        claimLoading: true,
+        releaseLoading: false,
+        rejectRemark: '',
+      },
+    })
+
+    expect(
+      wrapper.get('[data-test="action-domain.workOrder.action.claim"]').attributes(),
+    ).toMatchObject({
+      'data-loading': 'true',
+    })
+    expect(wrapper.find('[data-test="action-domain.workOrder.action.release"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="action-domain.workOrder.action.complete"]').exists()).toBe(
+      true,
+    )
+    expect(wrapper.find('[data-test="action-domain.workOrder.action.reopen"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="action-domain.workOrder.action.reject"]').exists()).toBe(true)
+
+    await wrapper
+      .get('[data-test="confirm-domain.workOrder.message.claimConfirm"]')
+      .trigger('click')
+    await wrapper
+      .get('[data-test="confirm-domain.workOrder.message.releaseConfirm"]')
+      .trigger('click')
+    await wrapper
+      .get('[data-test="confirm-domain.workOrder.message.completeConfirm"]')
+      .trigger('click')
+    await wrapper
+      .get('[data-test="confirm-domain.workOrder.message.reopenConfirm"]')
+      .trigger('click')
+    await wrapper.get('[data-test="confirm-custom"]').trigger('click')
+
+    expect(wrapper.emitted('claim')).toHaveLength(1)
+    expect(wrapper.emitted('release')).toHaveLength(1)
+    expect(wrapper.emitted('complete')).toHaveLength(1)
+    expect(wrapper.emitted('reopen')).toHaveLength(1)
+    expect(wrapper.emitted('reject')).toHaveLength(1)
+  })
+
+  it('emits reject remark updates and hides disabled actions', async () => {
+    const wrapper = mount(WorkOrderDetailActions, {
+      props: {
+        canClaim: false,
+        canRelease: false,
+        canComplete: false,
+        canReopen: false,
+        canReject: true,
+        rejectRemark: '旧备注',
+      },
+    })
+
+    expect(wrapper.find('[data-test="action-domain.workOrder.action.claim"]').exists()).toBe(false)
+    expect(wrapper.find('[data-test="action-domain.workOrder.action.release"]').exists()).toBe(
+      false,
+    )
+    expect(wrapper.find('[data-test="action-domain.workOrder.action.complete"]').exists()).toBe(
+      false,
+    )
+    expect(wrapper.find('[data-test="action-domain.workOrder.action.reopen"]').exists()).toBe(false)
+
+    await wrapper.get('[data-test="reject-remark"]').setValue('新备注')
+
+    expect(wrapper.emitted('update:rejectRemark')).toEqual([['新备注']])
+  })
+})

--- a/src/modules/work-order/presentation/__tests__/WorkOrderDetailHeader.spec.ts
+++ b/src/modules/work-order/presentation/__tests__/WorkOrderDetailHeader.spec.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it, vi } from 'vitest'
+import { defineComponent, h } from 'vue'
+import { mount } from '@vue/test-utils'
+import WorkOrderDetailHeader from '@/modules/work-order/presentation/WorkOrderDetailHeader'
+import { WorkOrderStatus } from '@/modules/work-order/domain/enums'
+import type { WorkOrderDetailVO } from '@/modules/work-order/domain/types'
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+vi.mock('@/modules/shared/presentation/time', () => ({
+  formatted: (value: string) => ({
+    standard: `formatted:${value}`,
+  }),
+}))
+
+vi.mock('@/modules/work-order/presentation/WorkOrderStatusBadge', () => ({
+  default: defineComponent({
+    name: 'WorkOrderStatusBadge',
+    props: {
+      status: {
+        type: String,
+        required: true,
+      },
+    },
+    setup(props) {
+      return () => h('span', { 'data-test': 'status-badge' }, props.status)
+    },
+  }),
+}))
+
+vi.mock('naive-ui', () => ({
+  NSpace: defineComponent({
+    name: 'NSpace',
+    setup(_, { slots }) {
+      return () => h('div', { 'data-test': 'n-space' }, slots.default?.())
+    },
+  }),
+  NText: defineComponent({
+    name: 'NText',
+    setup(_, { slots }) {
+      return () => h('span', { 'data-test': 'n-text' }, slots.default?.())
+    },
+  }),
+  NTag: defineComponent({
+    name: 'NTag',
+    emits: ['click'],
+    setup(_, { emit, slots }) {
+      return () =>
+        h('button', { 'data-test': 'cancel-tag', onClick: () => emit('click') }, slots.default?.())
+    },
+  }),
+  NPopconfirm: defineComponent({
+    name: 'NPopconfirm',
+    emits: ['positive-click'],
+    setup(_, { emit, slots }) {
+      return () =>
+        h('div', { 'data-test': 'popconfirm' }, [
+          slots.trigger?.(),
+          h(
+            'button',
+            { 'data-test': 'confirm-cancel', onClick: () => emit('positive-click') },
+            slots.default?.(),
+          ),
+        ])
+    },
+  }),
+}))
+
+const detail: WorkOrderDetailVO = {
+  id: 11,
+  categoryId: 2,
+  categoryName: '电表',
+  userId: 9,
+  userName: 'Alice',
+  currentHandlerId: 7,
+  currentHandlerName: 'Bob',
+  title: '工单标题',
+  status: WorkOrderStatus.PROCESSING,
+  score: null,
+  scoreDeadline: null,
+  completedAt: '2026-03-18T10:00:00+08:00',
+  createdTime: '2026-03-17T10:00:00+08:00',
+  updatedTime: '2026-03-17T10:00:00+08:00',
+  content: '工单内容',
+}
+
+describe('WorkOrderDetailHeader', () => {
+  it('renders detail summary and emits cancel from confirmation', async () => {
+    const wrapper = mount(WorkOrderDetailHeader, {
+      props: {
+        detail,
+        initiatorName: 'Alice#9',
+        claimerName: 'Bob#7',
+        canCancel: true,
+      },
+    })
+
+    expect(wrapper.text()).toContain('工单标题')
+    expect(wrapper.get('[data-test="status-badge"]').text()).toBe(WorkOrderStatus.PROCESSING)
+    expect(wrapper.text()).toContain('电表')
+    expect(wrapper.text()).toContain('formatted:2026-03-17T10:00:00+08:00')
+    expect(wrapper.text()).toContain('domain.workOrder.label.completedAt')
+    expect(wrapper.text()).toContain('formatted:2026-03-18T10:00:00+08:00')
+    expect(wrapper.text()).toContain('domain.workOrder.label.initiator: Alice#9')
+    expect(wrapper.text()).toContain('domain.workOrder.label.claimer: Bob#7')
+    expect(wrapper.get('[data-test="cancel-tag"]').text()).toBe('domain.workOrder.action.cancel')
+
+    await wrapper.get('[data-test="confirm-cancel"]').trigger('click')
+
+    expect(wrapper.emitted('cancel')).toHaveLength(1)
+  })
+
+  it('hides optional claimer and cancel control when unavailable', () => {
+    const wrapper = mount(WorkOrderDetailHeader, {
+      props: {
+        detail: {
+          ...detail,
+          completedAt: null,
+        },
+        initiatorName: 'Alice#9',
+        claimerName: null,
+        canCancel: false,
+      },
+    })
+
+    expect(wrapper.text()).not.toContain('domain.workOrder.label.claimer')
+    expect(wrapper.text()).not.toContain('domain.workOrder.label.completedAt')
+    expect(wrapper.find('[data-test="cancel-tag"]').exists()).toBe(false)
+  })
+})

--- a/src/modules/work-order/presentation/__tests__/WorkOrderReplyEditor.spec.ts
+++ b/src/modules/work-order/presentation/__tests__/WorkOrderReplyEditor.spec.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi } from 'vitest'
+import { defineAsyncComponent, defineComponent, h, nextTick, type Component } from 'vue'
+import { mount } from '@vue/test-utils'
+import WorkOrderReplyEditor from '@/modules/work-order/presentation/WorkOrderReplyEditor'
+
+vi.mock('naive-ui', () => ({
+  NCard: defineComponent({
+    name: 'NCard',
+    setup(_, { slots }) {
+      return () => h('section', { 'data-test': 'reply-editor-card' }, slots.default?.())
+    },
+  }),
+  NSpace: defineComponent({
+    name: 'NSpace',
+    setup(_, { slots }) {
+      return () => h('div', { 'data-test': 'reply-editor-space' }, slots.default?.())
+    },
+  }),
+  NSpin: defineComponent({
+    name: 'NSpin',
+    setup(_, { slots }) {
+      return () => h('div', { 'data-test': 'reply-editor-spin' }, slots.default?.())
+    },
+  }),
+}))
+
+const uploadHandler = vi.fn()
+
+const createAsyncEditor = () =>
+  defineAsyncComponent(
+    () =>
+      new Promise<Component>((resolve) => {
+        setTimeout(() => {
+          resolve(
+            defineComponent({
+              name: 'MockMdEditor',
+              props: {
+                modelValue: {
+                  type: String,
+                  default: '',
+                },
+                preview: {
+                  type: Boolean,
+                  default: true,
+                },
+                language: {
+                  type: String,
+                  default: '',
+                },
+                onOnUploadImg: {
+                  type: Function,
+                  default: undefined,
+                },
+              },
+              emits: ['update:modelValue'],
+              setup(props, { emit }) {
+                return () =>
+                  h(
+                    'button',
+                    {
+                      'data-test': 'mock-md-editor',
+                      'data-model-value': props.modelValue,
+                      'data-preview': String(props.preview),
+                      'data-language': props.language,
+                      'data-has-upload': String(props.onOnUploadImg === uploadHandler),
+                      onClick: () => emit('update:modelValue', '更新后的回复'),
+                    },
+                    props.modelValue,
+                  )
+              },
+            }),
+          )
+        }, 0)
+      }),
+  )
+
+describe('WorkOrderReplyEditor', () => {
+  it('renders loading shell while editor resolves and emits content updates', async () => {
+    const wrapper = mount(WorkOrderReplyEditor, {
+      props: {
+        editorComponent: createAsyncEditor(),
+        modelValue: '初始回复',
+        onUploadImg: uploadHandler,
+      },
+    })
+
+    expect(wrapper.find('[data-test="reply-editor-card"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="reply-editor-spin"]').exists()).toBe(true)
+    expect(wrapper.find('.markdown-editor-loading-placeholder').exists()).toBe(true)
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    await nextTick()
+
+    const editor = wrapper.get('[data-test="mock-md-editor"]')
+    expect(editor.attributes('data-model-value')).toBe('初始回复')
+    expect(editor.attributes('data-preview')).toBe('false')
+    expect(editor.attributes('data-language')).toBe('zh-CN')
+    expect(editor.attributes('data-has-upload')).toBe('true')
+
+    await editor.trigger('click')
+
+    expect(wrapper.emitted('update:modelValue')).toEqual([['更新后的回复']])
+  })
+})

--- a/src/modules/work-order/presentation/__tests__/WorkOrderReplyList.spec.ts
+++ b/src/modules/work-order/presentation/__tests__/WorkOrderReplyList.spec.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it, vi } from 'vitest'
+import { defineComponent, h } from 'vue'
+import { mount } from '@vue/test-utils'
+import WorkOrderReplyList from '@/modules/work-order/presentation/WorkOrderReplyList'
+import { WorkOrderUserType } from '@/modules/work-order/domain/enums'
+import type { WorkOrderReplyVO } from '@/modules/work-order/domain/types'
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+vi.mock('@/modules/shared/presentation/time', () => ({
+  formatted: (value: string) => ({
+    standard: `formatted:${value}`,
+  }),
+}))
+
+vi.mock('naive-ui', () => ({
+  NSpace: defineComponent({
+    name: 'NSpace',
+    setup(_, { slots }) {
+      return () => h('div', { 'data-test': 'n-space' }, slots.default?.())
+    },
+  }),
+  NText: defineComponent({
+    name: 'NText',
+    setup(_, { slots }) {
+      return () => h('span', { 'data-test': 'n-text' }, slots.default?.())
+    },
+  }),
+  NCard: defineComponent({
+    name: 'NCard',
+    props: {
+      style: {
+        type: Object,
+        default: undefined,
+      },
+    },
+    setup(props, { slots }) {
+      return () =>
+        h(
+          'section',
+          {
+            'data-test': 'reply-card',
+            'data-border-left': String(props.style?.borderLeft ?? ''),
+          },
+          [h('header', { 'data-test': 'reply-header' }, slots.header?.()), slots.default?.()],
+        )
+    },
+  }),
+}))
+
+const replies: WorkOrderReplyVO[] = [
+  {
+    id: 1,
+    workOrderId: 11,
+    userId: 9,
+    userName: 'Alice',
+    userType: WorkOrderUserType.USER,
+    content: '用户回复',
+    createdTime: '2026-03-17T10:00:00+08:00',
+  },
+  {
+    id: 2,
+    workOrderId: 11,
+    userId: 7,
+    userName: 'Bob',
+    userType: WorkOrderUserType.HANDLER,
+    content: '处理人回复',
+    createdTime: '2026-03-17T11:00:00+08:00',
+  },
+]
+
+describe('WorkOrderReplyList', () => {
+  it('renders reply count and empty state', () => {
+    const wrapper = mount(WorkOrderReplyList, {
+      props: {
+        replies: [],
+        replyAuthorName: () => '',
+        renderMarkdownPreview: () => h('div'),
+      },
+    })
+
+    expect(wrapper.text()).toContain('domain.workOrder.action.reply (0)')
+    expect(wrapper.text()).toContain('domain.workOrder.message.noReplies')
+    expect(wrapper.find('[data-test="reply-card"]').exists()).toBe(false)
+  })
+
+  it('renders replies with author metadata and markdown preview', () => {
+    const wrapper = mount(WorkOrderReplyList, {
+      props: {
+        replies,
+        replyAuthorName: (reply: WorkOrderReplyVO) => `author:${reply.userId}`,
+        renderMarkdownPreview: (content: string) =>
+          h('article', { 'data-test': 'markdown-preview' }, content),
+      },
+    })
+
+    expect(wrapper.text()).toContain('domain.workOrder.action.reply (2)')
+
+    const cards = wrapper.findAll('[data-test="reply-card"]')
+    expect(cards).toHaveLength(2)
+    expect(cards[0].attributes('data-border-left')).toBe('0.25rem solid var(--n-border-color)')
+    expect(cards[1].attributes('data-border-left')).toBe('0.25rem solid var(--n-color-target)')
+
+    expect(cards[0].text()).toContain('author:9')
+    expect(cards[0].text()).toContain('domain.workOrder.label.userReply')
+    expect(cards[0].text()).toContain('formatted:2026-03-17T10:00:00+08:00')
+    expect(cards[0].get('[data-test="markdown-preview"]').text()).toBe('用户回复')
+
+    expect(cards[1].text()).toContain('author:7')
+    expect(cards[1].text()).toContain('domain.workOrder.label.handlerReply')
+    expect(cards[1].text()).toContain('formatted:2026-03-17T11:00:00+08:00')
+    expect(cards[1].get('[data-test="markdown-preview"]').text()).toBe('处理人回复')
+  })
+})


### PR DESCRIPTION
## Summary
- Extract work-order detail permission and participant display rules into application-level rules.
- Add a composable detail state hook for user/handler query selection and reply mode resolution.
- Split the detail presentation into focused header, actions, reply list, and reply editor components with unit coverage.

## Test Plan
- pnpm test:unit --run "src/modules/work-order/presentation/__tests__/WorkOrderReplyEditor.spec.ts" "src/modules/work-order/presentation/__tests__/WorkOrderReplyList.spec.ts" "src/modules/work-order/presentation/__tests__/WorkOrderDetailHeader.spec.ts" "src/modules/work-order/presentation/__tests__/WorkOrderDetailActions.spec.ts" "src/modules/work-order/application/hooks/__tests__/useWorkOrderDetailState.spec.ts" "src/modules/work-order/application/rules/__tests__/workOrderDetailRules.spec.ts" "src/modules/work-order/application/rules/__tests__/workOrderParticipantRules.spec.ts" "src/modules/work-order/presentation/__tests__/WorkOrderListPage.spec.ts" "src/modules/work-order/presentation/__tests__/WorkOrderMarkdownCsp.spec.ts" "src/modules/work-order/presentation/__tests__/work-order-presentation-tsx.spec.ts"
- pnpm check