### PR TITLE
Publish versioned frontend release assets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: CI
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+      - 'work/**'
+  pull_request:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  release-package-check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: '9'
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Verify release package
+        run: bash scripts/release/frontend-package.sh
+        env:
+          RELEASE_TAG: v0.0.0-ci
+          RELEASE_ID: v0.0.0-ci
+          VITE_BACKEND_SERVER_URL: /api
+          VITE_OPENREPLAY_ENABLED: 'false'
+          VITE_OTEL_ENDPOINT: /observability/otel
+          VITE_SOURCEMAP_RESOLVER_ENDPOINT: /observability/resolver

--- a/.github/workflows/frontend-release.yml
+++ b/.github/workflows/frontend-release.yml
@@ -1,0 +1,76 @@
+name: Frontend Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: frontend-release-${{ github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  package:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      RELEASE_TAG: ${{ github.ref_name }}
+      RELEASE_ID: ${{ github.ref_name }}
+      REPO_COMMIT: ${{ github.sha }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: '9'
+
+      - name: Set up Node.js 24
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Package frontend release
+        run: bash scripts/release/frontend-package.sh
+        env:
+          VITE_APP_BUILD_ID: ${{ github.run_id }}
+          VITE_APP_RELEASE: ${{ env.RELEASE_ID }}
+          VITE_GIT_BRANCH: ${{ github.ref_name }}
+          VITE_GIT_COMMIT: ${{ github.sha }}
+          VITE_RELEASE_CHANNEL: prod-like
+          VITE_BACKEND_SERVER_URL: /api
+          VITE_OPENREPLAY_ENABLED: 'false'
+          VITE_OTEL_ENDPOINT: /observability/otel
+          VITE_SOURCEMAP_RESOLVER_ENDPOINT: /observability/resolver
+
+      - name: Publish immutable GitHub Release assets
+        run: |
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            echo "::error::GitHub Release already exists for $RELEASE_TAG; assets are immutable"
+            exit 1
+          fi
+          gh release create "$RELEASE_TAG" \
+            release-artifacts/* \
+            --verify-tag \
+            --title "Frontend $RELEASE_TAG" \
+            --generate-notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-release-${{ github.ref_name }}
+          path: release-artifacts/
+          retention-days: 30
+          if-no-files-found: error

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ node_modules
 .DS_Store
 dist
 dist-ssr
+release-artifacts
 coverage
 *.local
 

--- a/scripts/release/frontend-package.sh
+++ b/scripts/release/frontend-package.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd -P)
+REPO_ROOT=$(cd "$SCRIPT_DIR/../.." && pwd -P)
+cd "$REPO_ROOT"
+
+RELEASE_TAG=${RELEASE_TAG:-${GITHUB_REF_NAME:-}}
+if [[ -z "$RELEASE_TAG" && -n "${GITHUB_REF:-}" && "$GITHUB_REF" == refs/tags/* ]]; then
+  RELEASE_TAG=${GITHUB_REF#refs/tags/}
+fi
+[[ -n "$RELEASE_TAG" ]] || {
+  echo "RELEASE_TAG is not set and could not be inferred" >&2
+  exit 1
+}
+[[ "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]] || {
+  echo "Invalid RELEASE_TAG '$RELEASE_TAG'" >&2
+  exit 1
+}
+
+RELEASE_ID=${RELEASE_ID:-$RELEASE_TAG}
+REPO_COMMIT=${REPO_COMMIT:-$(git rev-parse --verify HEAD)}
+SANITIZED_TAG=${RELEASE_TAG//\//-}
+ARTIFACT_ROOT="$REPO_ROOT/release-artifacts"
+DIST_DIR="$REPO_ROOT/dist"
+
+rm -rf "$ARTIFACT_ROOT"
+mkdir -p "$ARTIFACT_ROOT"
+
+echo "[release-package] Running type-check"
+pnpm type-check
+
+echo "[release-package] Building frontend bundle for $RELEASE_TAG"
+pnpm build-only --sourcemap
+[[ -d "$DIST_DIR" ]] || {
+  echo "Expected build output at '$DIST_DIR'" >&2
+  exit 1
+}
+
+ASSET_BUNDLE="frontend-${SANITIZED_TAG}.tar.gz"
+SOURCEMAP_BUNDLE="frontend-${SANITIZED_TAG}-sourcemaps.tar.gz"
+METADATA_FILE="frontend-${SANITIZED_TAG}.metadata"
+
+tar -C "$DIST_DIR" --exclude='*.map' -czf "$ARTIFACT_ROOT/$ASSET_BUNDLE" .
+
+SOURCEMAP_STAGE="$ARTIFACT_ROOT/sourcemap-files"
+mkdir -p "$SOURCEMAP_STAGE"
+rsync -a --include '*/' --include '*.map' --exclude '*' \
+  "$DIST_DIR/" "$SOURCEMAP_STAGE/"
+MAP_COUNT=$(find "$SOURCEMAP_STAGE" -type f | wc -l)
+[[ "$MAP_COUNT" -gt 0 ]] || {
+  echo "No sourcemap files were collected from '$DIST_DIR'" >&2
+  exit 1
+}
+tar -C "$SOURCEMAP_STAGE" -czf "$ARTIFACT_ROOT/$SOURCEMAP_BUNDLE" .
+rm -rf "$SOURCEMAP_STAGE"
+
+ASSET_SHA=$(sha256sum "$ARTIFACT_ROOT/$ASSET_BUNDLE" | awk '{print $1}')
+SOURCEMAP_SHA=$(sha256sum "$ARTIFACT_ROOT/$SOURCEMAP_BUNDLE" | awk '{print $1}')
+
+cat <<METADATA > "$ARTIFACT_ROOT/$METADATA_FILE"
+release_id=$RELEASE_ID
+git_tag=$RELEASE_TAG
+git_commit=$REPO_COMMIT
+asset_bundle=$ASSET_BUNDLE
+asset_bundle_sha256=$ASSET_SHA
+sourcemap_bundle=$SOURCEMAP_BUNDLE
+sourcemap_bundle_sha256=$SOURCEMAP_SHA
+METADATA
+
+echo "[release-package] Generated $METADATA_FILE"
+ls -1 "$ARTIFACT_ROOT"


### PR DESCRIPTION
Adds PR-level release package verification and a tag workflow that publishes immutable frontend assets, SourceMaps, and SHA metadata. Local verification generated and inspected both archives for v0.1.0-cd.1.